### PR TITLE
include license in distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include licence.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license_file = licence.txt


### PR DESCRIPTION
The MIT license "shall be included in all copies or substantial portions of the Software", but you're currently not including it in your `sdist` or `bdist_wheel` files. The `MANIFEST.in` puts it in `sdist`s, and `setup.cfg` for wheels.