### PR TITLE
docs: build_folder => bin_folder

### DIFF
--- a/doc/python/installation.rst
+++ b/doc/python/installation.rst
@@ -160,7 +160,7 @@ If you experience problems with compilation (or numerical inaccuracies after a K
 .. code-block:: python
 
   import pykeops
-  print(pykeops.build_folder)
+  print(pykeops.bin_folder)
 
 
 


### PR DESCRIPTION
It's [named `bin_folder`](https://github.com/getkeops/keops/blob/71f3e14d3755c06163f03ada8b3adc0ca6dcfb66/pykeops/__init__.py#L19), not `build_folder`.