### PR TITLE
set_path: include python version in cache dir name

### DIFF
--- a/pykeops/common/set_path.py
+++ b/pykeops/common/set_path.py
@@ -1,5 +1,8 @@
 import os.path
+import sys
+
 import pykeops
+
 
 ###########################################################
 #             Set build_folder
@@ -10,17 +13,20 @@ def set_build_folder():
     This function set a default build folder that contains the python module compiled
     by pykeops.
     """
-    bf_source = os.path.dirname(os.path.abspath(__file__)) + os.path.sep + '..' + os.path.sep + 'build' + os.path.sep
+    bf_source = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'build')
     bf_home = os.path.expanduser('~')
+    name = 'pykeops-{}-{}'.format(pykeops.__version__, sys.implementation.cache_tag)
 
     if os.path.isdir(bf_source): # assume we are loading from source
-        build_folder  = bf_source
-    elif os.path.isdir(bf_home): # assume we are ussing wheel and home is accessible
-       build_folder = bf_home + os.path.sep + '.cache' + os.path.sep + 'pykeops-' + pykeops.__version__ + os.path.sep 
+        build_folder = bf_source
+    elif os.path.isdir(bf_home): # assume we are using wheel and home is accessible
+        build_folder = os.path.join(bf_home, '.cache', name)
     else: 
         import tempfile
-        build_folder = tempfile.mkdtemp(prefix='pykeops-' + pykeops.__version__) + os.path.sep
-        
+        build_folder = tempfile.mkdtemp(prefix=name)
+    
+    if not build_folder.endswith(os.path.sep):
+        build_folder += os.path.sep
     os.makedirs(build_folder, exist_ok=True)
 
     return build_folder


### PR DESCRIPTION
If you use pykeops from two different Python versions, it crashes. For example:

```
$ cat test.py
# from the docs, except use CPU backend
import numpy as np
import pykeops.numpy as pknp

x = np.arange(1, 10).reshape(-1, 3).astype('float32')
y = np.arange(3, 9).reshape(-1, 3).astype('float32')
my_conv = pknp.Genred('SqNorm2(x - y)', ['x = Vi(3)', 'y = Vj(3)'])
res = my_conv(x, y, backend='CPU')
assert res.shape == (2, 1)
print("okay")

$ conda create -y -n tmp36 python=3.6 numpy cmake
[...]
$ conda activate tmp36
$ pip install pykeops
$ python test.py
[...]
okay

$ conda create -y -n tmp37 python=3.7 numpy cmake
[...]
$ conda activate tmp37
$ pip install pykeops
$ python test.py
Traceback (most recent call last):
  File "run_test.py", line 8, in <module>
    my_conv = pknp.Genred('SqNorm2(x - y)', ['x = Vi(3)', 'y = Vj(3)'])
  File "/nfs/nhome/live/dougals/miniconda/envs/tmp37/lib/python3.7/site-packages/pykeops/numpy/generic/generic_red.py", line 114, in __init__
    self.myconv = LoadKEops(self.formula, self.aliases, self.dtype, 'numpy').import_module()
  File "/nfs/nhome/live/dougals/miniconda/envs/tmp37/lib/python3.7/site-packages/pykeops/common/keops_io.py", line 52, in import_module
    return importlib.import_module(self.dll_name)
  File "/nfs/nhome/live/dougals/miniconda/envs/tmp37/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 670, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 583, in module_from_spec
  File "<frozen importlib._bootstrap_external>", line 1043, in create_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
ImportError: dynamic module does not define module export function (PyInit_libKeOpsnumpy5ac3d464a2)

$ python -c 'import shutil, pykeops; shutil.rmtree(pykeops.bin_folder)'
$ python test.py
[...]
okay
```

The cache directory contains two `.so`s in this case, one with a full tag specific to the version (`libKeOpsnumpy5ac3d464a2.cpython-37m-x86_64-linux-gnu.so`) but also one that isn't (`libKeOpsnumpy5ac3d464a2.so`). There might be some proper way of allowing them to coexist in the same directory, which would be good e.g. also if the same home directory is used on different platforms. This PR just adds `sys.implementation.cache_tag`, eg `cpython-36`, to the default build folder name to work around this (as well as a bit of cleanup in the function overall).