### PR TITLE
Fixes missing core/utils/TypeUtils.h in setupy.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -141,6 +141,7 @@ setup(
             'keops/core/utils/CudaErrorCheck.cu',
             'keops/core/utils/CudaSizes.h',
             'keops/core/utils/Infinity.h',
+            'keops/core/utils/TypesUtils.h',
             'keops/core/link_autodiff.cpp',
             'keops/core/link_autodiff.cu',
             'keops/core/pre_headers.h',


### PR DESCRIPTION
Setup.py is missing 'core/utils/TypeUtils.h' and this onliner fixes this.

Edit: I had a typo in my commit message ("setupy.py") which I fixed but how do I edit the title of the pull request?