### PR TITLE
Add arc cosine function to keops

### DIFF
--- a/keops/core/formulas/maths/Acos.h
+++ b/keops/core/formulas/maths/Acos.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "core/utils/keops_math.h"
+#include "core/autodiff/VectorizedScalarUnaryOp.h"
+#include "core/formulas/maths/Sin.h"
+#include "core/formulas/maths/Minus.h"
+#include "core/formulas/maths/Mult.h"
+#include "core/formulas/maths/Inv.h"
+#include "core/formulas/maths/Sqrt.h"
+#include "core/formulas/maths/Subtract.h"
+#include "core/formulas/constants/IntConst.h"
+#include "core/formulas/maths/Square.h"
+
+
+namespace keops {
+
+//////////////////////////////////////////////////////////////
+////                ARCCOSINE :  Acos< F >                ////
+//////////////////////////////////////////////////////////////
+
+
+
+template<class F>
+struct Acos : VectorizedScalarUnaryOp<Acos, F> {
+
+  static void PrintIdString(::std::stringstream &str) { str << "Acos"; }
+
+  template < typename TYPE >
+  struct Operation_Scalar {
+    DEVICE INLINE void operator() (TYPE &out, TYPE &outF) {
+          out = keops_acos(outF);
+    }
+  };
+
+  template<class V, class GRADIN>
+  using DiffT = typename F::template DiffT<V, Mult<Minus<Inv<Sqrt<Subtract<IntConstant<1>, Square<F>>>>>, GRADIN>>;
+
+};
+
+#define Acos(f) KeopsNS<Acos<decltype(InvKeopsNS(f))>>()
+
+}

--- a/keops/core/formulas/maths/Readme.md
+++ b/keops/core/formulas/maths/Readme.md
@@ -27,6 +27,7 @@ Standard math functions :
  *      XLogX<F>                       : function F*log(F) (vectorized)
  *      Sin<F>                         : sine of F (vectorized)
  *      Cos<F>                         : cosine of F (vectorized)
+ *      Acos<F>                        : cosine of F (vectorized)
  *      Sign<F>                        : sign of F (vectorized)
  *      Step<F>                        : step of F (vectorized)
  *      ReLU<F>                        : ReLU of F (vectorized)

--- a/keops/core/utils/keops_math.h
+++ b/keops/core/utils/keops_math.h
@@ -19,7 +19,7 @@ template < typename TYPE > DEVICE INLINE TYPE keops_step(TYPE x) { return (x<0.0
 template < typename TYPE > DEVICE INLINE TYPE keops_sign(TYPE x) { return (x>0.0F)? 1.0f : ( (x<0.0f)? -1.0f : 0.0f ); }
 template < typename TYPE > DEVICE INLINE TYPE keops_sqrt(TYPE x) { return sqrt(x); }
 template < typename TYPE > DEVICE INLINE TYPE keops_rsqrt(TYPE x) { return 1.0f / sqrt(x); }
-
+template < typename TYPE > DEVICE INLINE TYPE keops_acos(TYPE x) { return acos(x); }
 #ifdef __CUDA_ARCH__
   
 DEVICE INLINE float keops_pow(float x, int n) { return powf(x,n); } 
@@ -32,6 +32,7 @@ DEVICE INLINE float keops_cos(float x) { return cosf(x); }
 DEVICE INLINE float keops_sin(float x) { return sinf(x); } 
 DEVICE INLINE float keops_sqrt(float x) { return sqrtf(x); } 
 DEVICE INLINE float keops_rsqrt(float x) { return rsqrtf(x); } 
+DEVICE INLINE float keops_acos(float x) { return acosf(x); }
 
 DEVICE INLINE double keops_rsqrt(double x) { return rsqrt(x); } 
    

--- a/keops/keops_includes.h
+++ b/keops/keops_includes.h
@@ -24,6 +24,7 @@
 #include "core/formulas/maths/Exp.h"
 #include "core/formulas/maths/Sin.h"
 #include "core/formulas/maths/Cos.h"
+#include "core/formulas/maths/Acos.h"
 #include "core/formulas/maths/Pow.h"
 #include "core/formulas/maths/Square.h"
 #include "core/formulas/maths/Inv.h"

--- a/pykeops/common/lazy_tensor.py
+++ b/pykeops/common/lazy_tensor.py
@@ -871,7 +871,16 @@ class GenericLazyTensor:
         the element-wise sine of ``x``.
         """
         return self.unary("Sin")
-    
+
+    def acos(self):
+        r"""
+        Element-wise arccosine - a unary operation.
+
+        ``x.acos()`` returns a :class:`LazyTensor` that encodes, symbolically,
+        the element-wise arccosine of ``x``.
+        """
+        return self.unary("Acos")
+
     def sqrt(self):
         r"""
         Element-wise square root - a unary operation.
@@ -1223,7 +1232,7 @@ class GenericLazyTensor:
         :param args: a tuple of int containing the graph of a permutation of the output
         :return:
         """
-        # permute = tuple(range(len(dimfa) + len(dimfb) - 2 * len(contfa)))
+        # permute = tuple(range(len(dimfa) + len(dimfb) - 2 * len(contfa)))
         opt_arg = ""
         for intseq in (dimfa, dimfb, contfa, contfb) + args:
             opt_arg += "Ind("


### PR DESCRIPTION
This PR adds an acos function to keops (Addressing Issue #22). It's likely incomplete since I don't know the best way to add a test and don't know how to add an explicit python operation (so we can do `LazyTensor.acos`). If somebody points me to the right place to add these, I'll happily update my PR.
 
I tested that my changes work locally with:

```python
import torch
from pykeops.torch import LazyTensor

device = 'cuda'  # I tested both with `cpu` and `cuda`

x = torch.rand(1000, 1) - 0.5
y = x.data.clone()
x = x.to(device)
y = y.to(device)
x.requires_grad = True
y.requires_grad = True

x_i = LazyTensor(x[:, None])
acosx_i = x_i.unary('Acos')

s1 = acosx_i.sum(0)
s2 = torch.sum(torch.acos(y))
print("s1 - s2", torch.abs(s1 - s2).item())
assert torch.abs(s1 - s2) < 1e-3

s1.backward()
s2.backward()

print("grad_s1 - grad_s2", torch.max(torch.abs(x.grad - y.grad)).item())
assert torch.max(torch.abs(x.grad - y.grad)) < 1e-3
```

