### PR TITLE
Add `Asin` to KeOps

### DIFF
--- a/keops/core/formulas/maths/Asin.h
+++ b/keops/core/formulas/maths/Asin.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "core/utils/keops_math.h"
+#include "core/autodiff/VectorizedScalarUnaryOp.h"
+#include "core/formulas/maths/Mult.h"
+#include "core/formulas/maths/Inv.h"
+#include "core/formulas/maths/Sqrt.h"
+#include "core/formulas/maths/Subtract.h"
+#include "core/formulas/constants/IntConst.h"
+#include "core/formulas/maths/Square.h"
+
+
+namespace keops {
+
+//////////////////////////////////////////////////////////////
+////                ARCSINE :  Asin< F >                ////
+//////////////////////////////////////////////////////////////
+
+template <class F>
+struct Asin : VectorizedScalarUnaryOp<Asin, F>
+{
+
+    static void PrintIdString(::std::stringstream &str) { str << "Asin"; }
+
+    template <typename TYPE>
+    struct Operation_Scalar
+    {
+        DEVICE INLINE void operator()(TYPE &out, TYPE &outF)
+        {
+            out = keops_asin(outF);
+        }
+    };
+
+    // dx = 1/sqrt(1 - x^2)
+    template <class V, class GRADIN>
+    using DiffT = typename F::template DiffT<V, Mult<Inv<Sqrt<Subtract<IntConstant<1>, Square<F>>>>, GRADIN>>;
+
+};
+
+#define Asin(f) KeopsNS<Asin<decltype(InvKeopsNS(f))>>()
+
+}

--- a/keops/core/formulas/maths/Readme.md
+++ b/keops/core/formulas/maths/Readme.md
@@ -28,6 +28,7 @@ Standard math functions :
  *      Sin<F>                         : sine of F (vectorized)
  *      Cos<F>                         : cosine of F (vectorized)
  *      Acos<F>                        : arc-cosine of F (vectorized)
+ *      Asin<F>                        : arc-sine of F (vectorized)
  *      Sign<F>                        : sign of F (vectorized)
  *      Step<F>                        : step of F (vectorized)
  *      ReLU<F>                        : ReLU of F (vectorized)

--- a/keops/core/utils/keops_math.h
+++ b/keops/core/utils/keops_math.h
@@ -23,6 +23,7 @@ template < typename TYPE > DEVICE INLINE TYPE keops_diffclampint(TYPE x, int a, 
 template < typename TYPE > DEVICE INLINE TYPE keops_sqrt(TYPE x) { return sqrt(x); }
 template < typename TYPE > DEVICE INLINE TYPE keops_rsqrt(TYPE x) { return 1.0f / sqrt(x); }
 template < typename TYPE > DEVICE INLINE TYPE keops_acos(TYPE x) { return acos(x); }
+template < typename TYPE > DEVICE INLINE TYPE keops_asin(TYPE x) { return asin(x); }
 
 #ifdef __CUDA_ARCH__  
 DEVICE INLINE float keops_pow(float x, int n) { return powf(x,n); } 
@@ -36,6 +37,7 @@ DEVICE INLINE float keops_sin(float x) { return sinf(x); }
 DEVICE INLINE float keops_sqrt(float x) { return sqrtf(x); } 
 DEVICE INLINE float keops_rsqrt(float x) { return rsqrtf(x); } 
 DEVICE INLINE float keops_acos(float x) { return acosf(x); }
+DEVICE INLINE float keops_asin(float x) { return asinf(x); }
 DEVICE INLINE double keops_rsqrt(double x) { return rsqrt(x); } 
    
 #if USE_HALF 

--- a/keops/keops_includes.h
+++ b/keops/keops_includes.h
@@ -62,6 +62,7 @@
 #include "core/formulas/maths/Subtract.h"
 #include "core/formulas/maths/Exp.h"
 #include "core/formulas/maths/Sin.h"
+#include "core/formulas/maths/Asin.h"
 #include "core/formulas/maths/Cos.h"
 #include "core/formulas/maths/Acos.h"
 #include "core/formulas/maths/Pow.h"

--- a/pykeops/common/lazy_tensor.py
+++ b/pykeops/common/lazy_tensor.py
@@ -1141,6 +1141,15 @@ class GenericLazyTensor:
         """
         return self.unary("Sin")
 
+    def asin(self):
+        r"""
+        Element-wise arcsine - a unary operation.
+
+        ``x.asin()`` returns a :class:`LazyTensor` that encodes, symbolically,
+        the element-wise arcsine of ``x``.
+        """
+        return self.unary("Asin")
+
     def acos(self):
         r"""
         Element-wise arccosine - a unary operation.


### PR DESCRIPTION
Adds `asin`

Test Plan:
```python
import pykeops
import torch
from pykeops.torch import LazyTensor

device = 'cpu' 

x = torch.rand(1000, 1) - 0.5
y = x.data.clone()
x = x.to(device)
y = y.to(device)
x.requires_grad = True
y.requires_grad = True

x_i = LazyTensor(x[:, None])
asinx_i = x_i.unary('Asin')

s1 = asinx_i.sum(0)
s2 = torch.sum(torch.asin(y))
print("s1 - s2", torch.abs(s1 - s2).item())
assert torch.abs(s1 - s2) < 1e-3, torch.abs(s1 - s2)

s1.backward()
s2.backward()

print("grad_s1 - grad_s2", torch.max(torch.abs(x.grad - y.grad)).item())
assert torch.max(torch.abs(x.grad - y.grad)) < 1e-3
```