### PR TITLE
Add `Atan` to KeOps

### DIFF
--- a/keops/core/formulas/maths/Atan.h
+++ b/keops/core/formulas/maths/Atan.h
@@ -4,7 +4,6 @@
 #include "core/autodiff/VectorizedScalarUnaryOp.h"
 #include "core/formulas/maths/Mult.h"
 #include "core/formulas/maths/Inv.h"
-#include "core/formulas/maths/Sqrt.h"
 #include "core/formulas/maths/Add.h"
 #include "core/formulas/constants/IntConst.h"
 #include "core/formulas/maths/Square.h"

--- a/keops/core/formulas/maths/Atan.h
+++ b/keops/core/formulas/maths/Atan.h
@@ -31,7 +31,7 @@ struct Atan : VectorizedScalarUnaryOp<Atan, F>
         }
     };
 
-    // dx = 1/sqrt(1 - x^2)
+    // dx = 1/(1 + x^2)
     template <class V, class GRADIN>
     using DiffT = typename F::template DiffT<V, Mult<Inv<Add<IntConstant<1>, Square<F>>>, GRADIN>>;
 

--- a/keops/core/formulas/maths/Atan.h
+++ b/keops/core/formulas/maths/Atan.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "core/utils/keops_math.h"
+#include "core/autodiff/VectorizedScalarUnaryOp.h"
+#include "core/formulas/maths/Mult.h"
+#include "core/formulas/maths/Inv.h"
+#include "core/formulas/maths/Sqrt.h"
+#include "core/formulas/maths/Add.h"
+#include "core/formulas/constants/IntConst.h"
+#include "core/formulas/maths/Square.h"
+
+
+namespace keops {
+
+//////////////////////////////////////////////////////////////
+////                ARCTANGENT :  Atan< F >               ////
+//////////////////////////////////////////////////////////////
+
+template <class F>
+struct Atan : VectorizedScalarUnaryOp<Atan, F>
+{
+
+    static void PrintIdString(::std::stringstream &str) { str << "Atan"; }
+
+    template <typename TYPE>
+    struct Operation_Scalar
+    {
+        DEVICE INLINE void operator()(TYPE &out, TYPE &outF)
+        {
+            out = keops_atan(outF);
+        }
+    };
+
+    // dx = 1/sqrt(1 - x^2)
+    template <class V, class GRADIN>
+    using DiffT = typename F::template DiffT<V, Mult<Inv<Add<IntConstant<1>, Square<F>>>, GRADIN>>;
+
+};
+
+#define Atan(f) KeopsNS<Atan<decltype(InvKeopsNS(f))>>()
+
+}

--- a/keops/core/formulas/maths/Readme.md
+++ b/keops/core/formulas/maths/Readme.md
@@ -28,6 +28,8 @@ Standard math functions :
  *      Sin<F>                         : sine of F (vectorized)
  *      Cos<F>                         : cosine of F (vectorized)
  *      Acos<F>                        : arc-cosine of F (vectorized)
+ *      Asin<F>                        : arc-sine of F (vectorized)
+ *      Atan<F>                        : arc-tangent of F (vectorized)
  *      Sign<F>                        : sign of F (vectorized)
  *      Step<F>                        : step of F (vectorized)
  *      ReLU<F>                        : ReLU of F (vectorized)

--- a/keops/core/utils/keops_math.h
+++ b/keops/core/utils/keops_math.h
@@ -23,6 +23,8 @@ template < typename TYPE > DEVICE INLINE TYPE keops_diffclampint(TYPE x, int a, 
 template < typename TYPE > DEVICE INLINE TYPE keops_sqrt(TYPE x) { return sqrt(x); }
 template < typename TYPE > DEVICE INLINE TYPE keops_rsqrt(TYPE x) { return 1.0f / sqrt(x); }
 template < typename TYPE > DEVICE INLINE TYPE keops_acos(TYPE x) { return acos(x); }
+template < typename TYPE > DEVICE INLINE TYPE keops_asin(TYPE x) { return asin(x); }
+template < typename TYPE > DEVICE INLINE TYPE keops_atan(TYPE x) { return atan(x); }
 
 #ifdef __CUDA_ARCH__  
 DEVICE INLINE float keops_pow(float x, int n) { return powf(x,n); } 
@@ -36,6 +38,8 @@ DEVICE INLINE float keops_sin(float x) { return sinf(x); }
 DEVICE INLINE float keops_sqrt(float x) { return sqrtf(x); } 
 DEVICE INLINE float keops_rsqrt(float x) { return rsqrtf(x); } 
 DEVICE INLINE float keops_acos(float x) { return acosf(x); }
+DEVICE INLINE float keops_asin(float x) { return asinf(x); }
+DEVICE INLINE float keops_atan(float x) { return atanf(x); }
 DEVICE INLINE double keops_rsqrt(double x) { return rsqrt(x); } 
    
 #if USE_HALF 

--- a/keops/core/utils/keops_math.h
+++ b/keops/core/utils/keops_math.h
@@ -24,10 +24,7 @@ template < typename TYPE > DEVICE INLINE TYPE keops_sqrt(TYPE x) { return sqrt(x
 template < typename TYPE > DEVICE INLINE TYPE keops_rsqrt(TYPE x) { return 1.0f / sqrt(x); }
 template < typename TYPE > DEVICE INLINE TYPE keops_acos(TYPE x) { return acos(x); }
 template < typename TYPE > DEVICE INLINE TYPE keops_asin(TYPE x) { return asin(x); }
-<<<<<<< HEAD
 template < typename TYPE > DEVICE INLINE TYPE keops_atan(TYPE x) { return atan(x); }
-=======
->>>>>>> 25707d3dc3adbb55f272f9603b163cd443b6e5f2
 
 #ifdef __CUDA_ARCH__  
 DEVICE INLINE float keops_pow(float x, int n) { return powf(x,n); } 

--- a/keops/keops_includes.h
+++ b/keops/keops_includes.h
@@ -80,6 +80,7 @@
 #include "core/formulas/maths/Powf.h"
 #include "core/formulas/maths/Sqrt.h"
 #include "core/formulas/maths/Rsqrt.h"
+#include "core/formulas/maths/Atan.h"
 #include "core/formulas/maths/MatVecMult.h"
 #include "core/formulas/maths/GradMatrix.h"
 #if ((__CUDACC_VER_MAJOR__ * 1000 + __CUDACC_VER_MINOR__ * 100 + __CUDACC_VER_BUILD__) >= 11100)

--- a/pykeops/common/lazy_tensor.py
+++ b/pykeops/common/lazy_tensor.py
@@ -1150,6 +1150,15 @@ class GenericLazyTensor:
         """
         return self.unary("Acos")
 
+    def atan(self):
+        r"""
+        Element-wise arctangent - a unary operation.
+
+        ``x.atan()`` returns a :class:`LazyTensor` that encodes, symbolically,
+        the element-wise arccosine of ``x``.
+        """
+        return self.unary("Atan")
+
     def sqrt(self):
         r"""
         Element-wise square root - a unary operation.

--- a/pykeops/common/lazy_tensor.py
+++ b/pykeops/common/lazy_tensor.py
@@ -1164,7 +1164,7 @@ class GenericLazyTensor:
         Element-wise arctangent - a unary operation.
 
         ``x.atan()`` returns a :class:`LazyTensor` that encodes, symbolically,
-        the element-wise arccosine of ``x``.
+        the element-wise arctangent of ``x``.
         """
         return self.unary("Atan")
 

--- a/pykeops/test/unit_tests_pytorch.py
+++ b/pykeops/test/unit_tests_pytorch.py
@@ -622,6 +622,41 @@ class PytorchUnitTestCase(unittest.TestCase):
             )
 
     ############################################################
+    def test_LazyTensor_asin(self):
+        ############################################################
+        from pykeops.torch import LazyTensor
+
+        full_results = []
+        for use_keops in [True, False]:
+
+            results = []
+
+            # N.B.: We could loop over float32 and float64, but this would take longer...
+            for (x,) in [(self.Xc,)]:  # Float32
+
+                x = x.unsqueeze(-2)
+
+                if use_keops:
+                    x, = (
+                        LazyTensor(x),
+                    )
+
+                x_asin = x.asin()
+                results += [(x_asin)]
+
+            full_results.append(results)
+
+        for (res_keops, res_torch) in zip(full_results[0], full_results[1]):
+            self.assertTrue(res_keops.shape == res_torch.shape)
+            self.assertTrue(
+                np.allclose(
+                    res_keops.cpu().data.numpy().ravel(),
+                    res_torch.cpu().data.numpy().ravel(),
+                    atol=1e-5,
+                )
+            )
+
+    ############################################################
     def test_TensorDot_with_permute(self):
         ############################################################
         import torch

--- a/pykeops/test/unit_tests_pytorch.py
+++ b/pykeops/test/unit_tests_pytorch.py
@@ -622,41 +622,6 @@ class PytorchUnitTestCase(unittest.TestCase):
             )
 
     ############################################################
-    def test_LazyTensor_asin(self):
-        ############################################################
-        from pykeops.torch import LazyTensor
-
-        full_results = []
-        for use_keops in [True, False]:
-
-            results = []
-
-            # N.B.: We could loop over float32 and float64, but this would take longer...
-            for (x,) in [(self.Xc,)]:  # Float32
-
-                x = x.unsqueeze(-2)
-
-                if use_keops:
-                    x, = (
-                        LazyTensor(x),
-                    )
-
-                x_asin = x.asin()
-                results += [(x_asin)]
-
-            full_results.append(results)
-
-        for (res_keops, res_torch) in zip(full_results[0], full_results[1]):
-            self.assertTrue(res_keops.shape == res_torch.shape)
-            self.assertTrue(
-                np.allclose(
-                    res_keops.cpu().data.numpy().ravel(),
-                    res_torch.cpu().data.numpy().ravel(),
-                    atol=1e-5,
-                )
-            )
-
-    ############################################################
     def test_TensorDot_with_permute(self):
         ############################################################
         import torch


### PR DESCRIPTION
Adds `atan`

Test Plan:
```python
import pykeops
pykeops.clean_pykeops()
import torch
from pykeops.torch import LazyTensor

device = 'cpu'

x = torch.rand(1000, 1) - 0.5
y = x.data.clone()
x = x.to(device)
y = y.to(device)
x.requires_grad = True
y.requires_grad = True

x_i = LazyTensor(x[:, None])
atanx_i = x_i.unary('Atan')

s1 = atanx_i.sum(0)
s2 = torch.sum(torch.atan(y))
print("s1 - s2", torch.abs(s1 - s2).item())
assert torch.abs(s1 - s2) < 1e-3, torch.abs(s1 - s2)

s1.backward()
s2.backward()

print("grad_s1 - grad_s2", torch.max(torch.abs(x.grad - y.grad)).item())
assert torch.max(torch.abs(x.grad - y.grad)) < 1e-3
```