### PR TITLE
Modulo with offset operation on LazyTensors

### DIFF
--- a/keops/core/formulas/maths/Mod.h
+++ b/keops/core/formulas/maths/Mod.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <sstream>
+
+#include "core/utils/keops_math.h"
+#include "core/autodiff/VectorizedScalarTernaryOp.h"
+
+
+
+namespace keops {
+
+//////////////////////////////////////////////////////////////
+////                 MODULO :  Mod< F, A, B >             ////
+//////////////////////////////////////////////////////////////
+
+
+template<class F, class G, class H>
+struct Mod : VectorizedScalarTernaryOp<Mod, F, G, H> {
+  
+  static void PrintIdString(::std::stringstream &str) { str << "Mod"; }
+
+  template < typename TYPE > 
+  struct Operation_Scalar {
+	  DEVICE INLINE void operator()(TYPE &out, TYPE &outF, TYPE &outG, TYPE &outH) {
+		  out = keops_mod(outF, outG, outH);
+	  }
+  };
+
+  template<class V, class GRADIN>
+  using DiffT = typename F::template DiffT<V,GRADIN>;
+
+};
+
+#define Mod(f,g,h) KeopsNS<Mod<decltype(InvKeopsNS(f)),decltype(InvKeopsNS(g)),decltype(InvKeopsNS(h))>>()
+
+}

--- a/keops/core/formulas/maths/Readme.md
+++ b/keops/core/formulas/maths/Readme.md
@@ -36,6 +36,7 @@ Standard math functions :
  *      Sign<F>                        : sign of F (vectorized)
  *      ClampInt<F,A,B>                : clamping of F in [A,B] (vectorized) ; F is function, A and B are integers
  *      Clamp<F,G,H>                   : clamping of F in [G,H] (vectorized) ; F, G, H are functions
+ *      Mod<FA,FB,FC>                  : modulo of FA with modulus FB and offset FC (vectorized)
  
 Concatenation and matrix-vector products:
  *      Concat<FA,FB>                  : concatenation of FB and FB

--- a/keops/core/utils/keops_math.h
+++ b/keops/core/utils/keops_math.h
@@ -22,6 +22,7 @@ template < typename TYPE > DEVICE INLINE TYPE keops_clampint(TYPE x, int a, int 
 template < typename TYPE > DEVICE INLINE TYPE keops_diffclampint(TYPE x, int a, int b) { return (x<a)? 0.0f : ( (x>b)? 0.0f : 1.0f ); }
 template < typename TYPE > DEVICE INLINE TYPE keops_sqrt(TYPE x) { return sqrt(x); }
 template < typename TYPE > DEVICE INLINE TYPE keops_rsqrt(TYPE x) { return 1.0f / sqrt(x); }
+template < typename TYPE > DEVICE INLINE TYPE keops_mod(TYPE x, TYPE n, TYPE d) { return x - n * floor((x - d)/n); }
 template < typename TYPE > DEVICE INLINE TYPE keops_acos(TYPE x) { return acos(x); }
 template < typename TYPE > DEVICE INLINE TYPE keops_asin(TYPE x) { return asin(x); }
 template < typename TYPE > DEVICE INLINE TYPE keops_atan(TYPE x) { return atan(x); }

--- a/keops/keops_includes.h
+++ b/keops/keops_includes.h
@@ -78,6 +78,7 @@
 #include "core/formulas/maths/ReLu.h"
 #include "core/formulas/maths/Clamp.h"
 #include "core/formulas/maths/ClampInt.h"
+#include "core/formulas/maths/Mod.h"
 #include "core/formulas/maths/Powf.h"
 #include "core/formulas/maths/Sqrt.h"
 #include "core/formulas/maths/Rsqrt.h"

--- a/pykeops/common/lazy_tensor.py
+++ b/pykeops/common/lazy_tensor.py
@@ -1289,6 +1289,16 @@ class GenericLazyTensor:
             return self.unary("ClampInt", opt_arg=other1, opt_arg2=other2)
         else:
             return self.ternary(other1, other2, "Clamp", dimcheck="sameor1")
+    
+    def mod(self, modulus, offset):
+        r"""
+        Element-wise modulo with offset function - a ternary operation.
+
+        ``x.mod(a,b)`` returns a :class:`LazyTensor` that encodes, symbolically,
+        the element-wise modulo of ``x`` with modulus ``a`` and offset ``b``. Braodcasting 
+        rules apply. a and b are floats.
+        """
+        return self.ternary(modulus, offset, "Mod", dimcheck="sameor1")
 
     def sqnorm2(self):
         r"""


### PR DESCRIPTION
Adds modulo with offset operation on LazyTensors

Test Plan:
```
import pykeops
import torch
import math
from pykeops.torch import LazyTensor

def torch_mod(input, modulus, offset):
    return input - modulus * torch.floor((input - offset)/modulus)

device = 'cuda' 

x = torch.rand(1000, 1)*2*math.pi
y = x.data.clone()
x = x.to(device)
y = y.to(device)
x.requires_grad = True
y.requires_grad = True

x_i = LazyTensor(x[:, None])
s1 = x_i.mod(math.pi, -math.pi/2).sum(0)
s2 = torch.sum(torch_mod(y, math.pi, -math.pi/2))
print("s1 - s2", torch.abs(s1 - s2).item())
assert torch.abs(s1 - s2) < 1e-3, torch.abs(s1 - s2)

s1.backward()
s2.backward()

print("grad_s1 - grad_s2", torch.max(torch.abs(x.grad - y.grad)).item())
assert torch.max(torch.abs(x.grad - y.grad)) < 1e-3
```