### PR TITLE
atan2 operator

### DIFF
--- a/keops/core/formulas/maths/Atan2.h
+++ b/keops/core/formulas/maths/Atan2.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <assert.h>
+
+#include "core/pack/CondType.h"
+#include "core/autodiff/BinaryOp.h"
+#include "core/formulas/constants/Zero.h"
+#include "core/formulas/constants/IntConst.h"
+#include "core/formulas/maths/Sum.h"
+#include "core/formulas/maths/Scal.h"
+#include "core/utils/keops_math.h"
+
+#include "core/formulas/maths/Square.h"
+#include "core/formulas/maths/Divide.h"
+#include "core/formulas/maths/Mult.h"
+#include "core/formulas/maths/Subtract.h"
+
+
+namespace keops {
+
+//////////////////////////////////////////////////////////////
+////              Atan2 :  Atan2< FA, Fb >                ////
+//////////////////////////////////////////////////////////////
+
+//using namespace keops;
+
+template < class FA, class FB >
+struct Atan2_Impl : BinaryOp< Atan2_Impl, FA, FB > {
+
+  // Output dim = FA::DIM = FB::DIM
+  static const int DIM = FA::DIM;
+  static_assert(DIM == FB::DIM, "Dimensions must be the same for Atan2");
+
+  static void PrintIdString(::std::stringstream &str) { str << "Atan2"; }
+
+  template < typename TYPE >
+  static DEVICE INLINE void Operation(TYPE* out, TYPE* outA, TYPE* outB) {
+    #pragma unroll
+    for (int k = 0; k < DIM; k++) {
+      out[k] = keops_atan2(outA[k], outB[k]);
+    }
+  }
+
+  // [ \partial_V Atan2(A, B) ] . gradin = [ -(A / A^2 + B^2) . \partial_V A ] . gradin  + [ (B / A^2 + B^2) . \partial_V B ] . gradin
+  template < class V, class GRADIN>
+  using partial_FA = typename FA::template DiffT< V, Mult< Divide<FA, Add<Square<FA>, Square<FB>> >, GRADIN> >;
+  template < class V, class GRADIN>
+  using partial_FB = typename FB::template DiffT< V, Mult< Divide<FB, Add<Square<FA>, Square<FB>> >, GRADIN> >;
+
+  template < class V, class GRADIN >
+  using DiffT = Subtract<partial_FB<V, GRADIN>, partial_FA<V, GRADIN>>;
+
+};
+
+#define Atan2(fa, fb) KeopsNS<Atan2_Impl<decltype(InvKeopsNS(fa)), decltype(InvKeopsNS(fb))>>()
+
+}

--- a/keops/core/formulas/maths/Readme.md
+++ b/keops/core/formulas/maths/Readme.md
@@ -30,6 +30,7 @@ Standard math functions :
  *      Acos<F>                        : arc-cosine of F (vectorized)
  *      Asin<F>                        : arc-sine of F (vectorized)
  *      Atan<F>                        : arc-tangent of F (vectorized)
+ *      Atan2<A, B>                    : atan2(A, B) (vectorized)
  *      Sign<F>                        : sign of F (vectorized)
  *      Step<F>                        : step of F (vectorized)
  *      ReLU<F>                        : ReLU of F (vectorized)

--- a/keops/core/utils/keops_math.h
+++ b/keops/core/utils/keops_math.h
@@ -25,6 +25,7 @@ template < typename TYPE > DEVICE INLINE TYPE keops_rsqrt(TYPE x) { return 1.0f 
 template < typename TYPE > DEVICE INLINE TYPE keops_acos(TYPE x) { return acos(x); }
 template < typename TYPE > DEVICE INLINE TYPE keops_asin(TYPE x) { return asin(x); }
 template < typename TYPE > DEVICE INLINE TYPE keops_atan(TYPE x) { return atan(x); }
+template < typename TYPE > DEVICE INLINE TYPE keops_atan2(TYPE x, TYPE y) { return atan2(x, y); }
 
 #ifdef __CUDA_ARCH__  
 DEVICE INLINE float keops_pow(float x, int n) { return powf(x,n); } 
@@ -40,6 +41,7 @@ DEVICE INLINE float keops_rsqrt(float x) { return rsqrtf(x); }
 DEVICE INLINE float keops_acos(float x) { return acosf(x); }
 DEVICE INLINE float keops_asin(float x) { return asinf(x); }
 DEVICE INLINE float keops_atan(float x) { return atanf(x); }
+DEVICE INLINE float keops_atan2(float x, float y) { return atan2f(x, y); }
 DEVICE INLINE double keops_rsqrt(double x) { return rsqrt(x); } 
    
 #if USE_HALF 

--- a/keops/keops_includes.h
+++ b/keops/keops_includes.h
@@ -82,6 +82,7 @@
 #include "core/formulas/maths/Sqrt.h"
 #include "core/formulas/maths/Rsqrt.h"
 #include "core/formulas/maths/Atan.h"
+#include "core/formulas/maths/Atan2.h"
 #include "core/formulas/maths/MatVecMult.h"
 #include "core/formulas/maths/GradMatrix.h"
 #if ((__CUDACC_VER_MAJOR__ * 1000 + __CUDACC_VER_MINOR__ * 100 + __CUDACC_VER_BUILD__) >= 11100)


### PR DESCRIPTION
This PR implements the atan2 operator in keops as well as it's derivative. I just notived that #138 implements such an operator but does not have the derivative and doesn't appear to handle vector inputs. 

Here's a small test to show this works:

```python
import pykeops.torch as keops
import torch
import numpy as np

dtype = torch.float64
str_dtype = 'float64' if dtype == torch.float64 else 'float32'

formula = "Atan2(X, Y) * v"
aliases = ['X = Vi(1)', 'Y = Vj(1)', 'v = Vj(1)']
red = keops.Genred(formula, aliases, reduction_op="Sum", axis=1, dtype=str_dtype)

# Generate some data
N = 100
a = torch.rand(N, 1).to(dtype); b = torch.rand(N, 1).to(dtype); v = torch.ones(N, 1).to(dtype)

# Applying the reduction
res_red = red(a, b, v, backend="CPU").squeeze()

# Doing the operation directly without keops
K = torch.atan2(a.squeeze().unsqueeze(1), b.squeeze().unsqueeze(0))
res_dir = K @ v.squeeze()

# Ensure the results are close
print(torch.max(torch.abs(res_red - res_dir)))

# Now do the gradient part
a1, b1 = a.clone(), b.clone()

# Compute some gradients using the reduction
a.requires_grad = True
b.requires_grad = True
res_red = red(a, b, v, backend="CPU").squeeze()
loss = res_red.norm()
loss.backward()
a_grad = a.grad.detach().cpu().numpy()
b_grad = b.grad.detach().cpu().numpy()

# Now do the same without keops
a1.requires_grad = True
b1.requires_grad = True
K = torch.atan2(a1.squeeze().unsqueeze(1), b1.squeeze().unsqueeze(0))
res_dir = K @ v.squeeze()
loss2 = res_dir.norm()
loss2.backward()
a1_grad = a.grad.detach().cpu().numpy()
b1_grad = b.grad.detach().cpu().numpy()

# Make sure the gradients match up
print(np.max(np.abs(a_grad - a1_grad)))
print(np.max(np.abs(b_grad - b1_grad)))

````