### PR TITLE
Add if-else function

### DIFF
--- a/keops/core/formulas/maths/IfElse.h
+++ b/keops/core/formulas/maths/IfElse.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <sstream>
+
+#include "core/autodiff/VectorizedScalarTernaryOp.h"
+#include "core/utils/keops_math.h"
+
+namespace keops {
+
+template <class F, class G, class H>
+struct IfElse : VectorizedScalarTernaryOp<IfElse, F, G, H> {
+
+  static void PrintIdString(::std::stringstream &str) { str << "IfElse"; }
+
+  template <typename TYPE> struct Operation_Scalar {
+    DEVICE INLINE void operator()(TYPE &out, TYPE &outF, TYPE &outG, TYPE &outH) {
+      out = keops_ifelse(outF, outG, outH);
+    }
+  };
+
+  template <class V, class GRADIN>
+  using DiffT = IfElse<F, typename G::template DiffT<V, GRADIN>, typename H::template DiffT<V, GRADIN>>;
+};
+
+#define IfElse(f, g, h) KeopsNS<IfElse<decltype(InvKeopsNS(f)), decltype(InvKeopsNS(g)),decltype(InvKeopsNS(h))>>()
+
+} // namespace keops

--- a/keops/core/formulas/maths/Readme.md
+++ b/keops/core/formulas/maths/Readme.md
@@ -37,7 +37,7 @@ Standard math functions :
  *      Sign<F>                        : sign of F (vectorized)
  *      ClampInt<F,A,B>                : clamping of F in [A,B] (vectorized) ; F is function, A and B are integers
  *      Clamp<F,G,H>                   : clamping of F in [G,H] (vectorized) ; F, G, H are functions
- *      IfElse<F,G,H>                  : return G where F < 0 and H where F >= 0 (vectorized) ; F, G, H are functions
+ *      IfElse<F,G,H>                  : return G where F >= 0 and H where F < 0 (vectorized) ; F, G, H are functions
  *      Mod<FA,FB,FC>                  : modulo of FA with modulus FB and offset FC (vectorized)
  *      Round<F,A>                     : round of F to A decimal places (vectorized) ; F is function, A is integer
  

--- a/keops/core/formulas/maths/Readme.md
+++ b/keops/core/formulas/maths/Readme.md
@@ -37,6 +37,7 @@ Standard math functions :
  *      Sign<F>                        : sign of F (vectorized)
  *      ClampInt<F,A,B>                : clamping of F in [A,B] (vectorized) ; F is function, A and B are integers
  *      Clamp<F,G,H>                   : clamping of F in [G,H] (vectorized) ; F, G, H are functions
+ *      IfElse<F,G,H>                  : return G where F < 0 and H where F >= 0 (vectorized) ; F, G, H are functions
  *      Mod<FA,FB,FC>                  : modulo of FA with modulus FB and offset FC (vectorized)
  *      Round<F,A>                     : round of F to A decimal places (vectorized) ; F is function, A is integer
  

--- a/keops/core/utils/keops_math.h
+++ b/keops/core/utils/keops_math.h
@@ -22,7 +22,7 @@ template < typename TYPE > DEVICE INLINE TYPE keops_clamp(TYPE x, TYPE a, TYPE b
 template < typename TYPE > DEVICE INLINE TYPE keops_clampint(TYPE x, int a, int b) { return (x<a)? a : ( (x>b)? b : x ); }
 template < typename TYPE > DEVICE INLINE TYPE keops_round(TYPE x, int d) { return d ? round(x * pow(10, d))/pow(10, d) : round(x); }
 template < typename TYPE > DEVICE INLINE TYPE keops_diffclampint(TYPE x, int a, int b) { return (x<a)? 0.0f : ( (x>b)? 0.0f : 1.0f ); }
-template < typename TYPE > DEVICE INLINE TYPE keops_ifelse(TYPE x, TYPE a, TYPE b) { return (x<0.0f)? a : b; }
+template < typename TYPE > DEVICE INLINE TYPE keops_ifelse(TYPE x, TYPE a, TYPE b) { return (x>=0.0f) ? a : b; }
 template < typename TYPE > DEVICE INLINE TYPE keops_sqrt(TYPE x) { return sqrt(x); }
 template < typename TYPE > DEVICE INLINE TYPE keops_rsqrt(TYPE x) { return 1.0f / sqrt(x); }
 template < typename TYPE > DEVICE INLINE TYPE keops_mod(TYPE x, TYPE n, TYPE d) { return x - n * floor((x - d)/n); }

--- a/keops/core/utils/keops_math.h
+++ b/keops/core/utils/keops_math.h
@@ -22,6 +22,7 @@ template < typename TYPE > DEVICE INLINE TYPE keops_clamp(TYPE x, TYPE a, TYPE b
 template < typename TYPE > DEVICE INLINE TYPE keops_clampint(TYPE x, int a, int b) { return (x<a)? a : ( (x>b)? b : x ); }
 template < typename TYPE > DEVICE INLINE TYPE keops_round(TYPE x, int d) { return d ? round(x * pow(10, d))/pow(10, d) : round(x); }
 template < typename TYPE > DEVICE INLINE TYPE keops_diffclampint(TYPE x, int a, int b) { return (x<a)? 0.0f : ( (x>b)? 0.0f : 1.0f ); }
+template < typename TYPE > DEVICE INLINE TYPE keops_ifelse(TYPE x, TYPE a, TYPE b) { return (x<0.0f)? a : b; }
 template < typename TYPE > DEVICE INLINE TYPE keops_sqrt(TYPE x) { return sqrt(x); }
 template < typename TYPE > DEVICE INLINE TYPE keops_rsqrt(TYPE x) { return 1.0f / sqrt(x); }
 template < typename TYPE > DEVICE INLINE TYPE keops_mod(TYPE x, TYPE n, TYPE d) { return x - n * floor((x - d)/n); }

--- a/keops/keops_includes.h
+++ b/keops/keops_includes.h
@@ -78,6 +78,7 @@
 #include "core/formulas/maths/ReLu.h"
 #include "core/formulas/maths/Clamp.h"
 #include "core/formulas/maths/ClampInt.h"
+#include "core/formulas/maths/IfElse.h"
 #include "core/formulas/maths/Mod.h"
 #include "core/formulas/maths/Round.h"
 #include "core/formulas/maths/Powf.h"

--- a/pykeops/common/lazy_tensor.py
+++ b/pykeops/common/lazy_tensor.py
@@ -1361,16 +1361,11 @@ class GenericLazyTensor:
 
     def ifelse(self, other1, other2):
         r"""
-        Element-wise modulo with offset function - a ternary operation.
         Element-wise if-else function - a ternary operation.
 
-        ``x.mod(a,b)`` returns a :class:`LazyTensor` that encodes, symbolically,
-        the element-wise modulo of ``x`` with modulus ``a`` and offset ``b``.
-        By default b=0, so that x.mod(a) becomes equivalent to the NumPy function mod.
-        Broadcasting rules apply. a and b are fixed integers or float.
         ``x.ifelse(a,b)`` returns a :class:`LazyTensor` that encodes, symbolically,
-        ``a`` where ``x < 0`` and ``b`` where ``x >= 0``.  Broadcasting rules apply.
-        a and b may be fixed integers or floats, or other LazyTensors
+        ``a`` where ``x >= 0`` and ``b`` where ``x < 0``.  Broadcasting rules apply.
+        a and b may be fixed integers or floats, or other LazyTensors.
         """
         return self.ternary(other1, other2, "IfElse", dimcheck="sameor1")
 

--- a/pykeops/common/lazy_tensor.py
+++ b/pykeops/common/lazy_tensor.py
@@ -1359,6 +1359,21 @@ class GenericLazyTensor:
         else:
             return self.ternary(other1, other2, "Clamp", dimcheck="sameor1")
 
+    def ifelse(self, other1, other2):
+        r"""
+        Element-wise modulo with offset function - a ternary operation.
+        Element-wise if-else function - a ternary operation.
+
+        ``x.mod(a,b)`` returns a :class:`LazyTensor` that encodes, symbolically,
+        the element-wise modulo of ``x`` with modulus ``a`` and offset ``b``.
+        By default b=0, so that x.mod(a) becomes equivalent to the NumPy function mod.
+        Broadcasting rules apply. a and b are fixed integers or float.
+        ``x.ifelse(a,b)`` returns a :class:`LazyTensor` that encodes, symbolically,
+        ``a`` where ``x < 0`` and ``b`` where ``x >= 0``.  Broadcasting rules apply.
+        a and b may be fixed integers or floats, or other LazyTensors
+        """
+        return self.ternary(other1, other2, "IfElse", dimcheck="sameor1")
+
     def mod(self, modulus, offset=0):
         r"""
         Element-wise modulo with offset function - a ternary operation.


### PR DESCRIPTION
This PR adds an if-else function to keops, addressing discussion in #104. The proposed function takes arguments `f`, `g` and `h`, and returns `g` where `f < 0` and `h` where `f >= 0`. I've tested with the following:
```python
import torch
from pykeops.torch import LazyTensor

ttypes = (torch.FloatTensor, torch.cuda.FloatTensor)

# Test when LazyTensors share underlying data
for ttype in ttypes:
    torch.set_default_tensor_type(ttype)

    # Input
    f = torch.randn([1000, 1])
    f.requires_grad = True
    f_i = LazyTensor(f[:, None, :])

    f_ref = f.detach().clone()
    f_ref.requires_grad = True

    # Values
    first = lambda x: x * x * x
    second = lambda x: x.sqrt()
    val = f_i.ifelse(first(f_i), second(f_i)).sum(dim=0)
    val_refs = torch.zeros_like(f_ref)
    val_refs[f_ref < 0] = first(f_ref[f_ref < 0])
    val_refs[f_ref >= 0] = second(f_ref[f_ref >= 0])
    val_ref = val_refs.sum(dim=0)

    print("Checking values")
    print(f"|val - val_ref|: {(val - val_ref).abs()}\n")
    assert torch.allclose(val, val_ref)

    # Gradients
    val.backward()
    val_ref.backward()
    print("Checking gradients:")
    print(f"max(|grad - grad_ref|): {(f.grad - f_ref.grad).abs().max()}\n")
    assert torch.allclose(f.grad, f_ref.grad)


# Test when other LazyTensors don't share underlying data (maybe unnecessary)
for ttype in ttypes:
    torch.set_default_tensor_type(ttype)

    # Input
    f = torch.randn([1000, 1])
    g = torch.randn_like(f)
    h = torch.randn_like(f).abs()
    f.requires_grad = True
    g.requires_grad = True
    h.requires_grad = True
    f_i = LazyTensor(f[:, None, :])
    g_i = LazyTensor(g[:, None, :])
    h_i = LazyTensor(h[:, None, :])

    f_ref = f.detach().clone()
    g_ref = g.detach().clone()
    h_ref = h.detach().clone()
    f_ref.requires_grad = True
    g_ref.requires_grad = True
    h_ref.requires_grad = True

    # Values
    first = lambda x: x * x * x
    second = lambda x: x.sqrt()
    val = f_i.ifelse(first(g_i), second(h_i)).sum(dim=0)
    val_refs = torch.zeros_like(f_ref)
    val_refs[f_ref < 0] = first(g_ref[f_ref < 0])
    val_refs[f_ref >= 0] = second(h_ref[f_ref >= 0])
    val_ref = val_refs.sum(dim=0)

    print("Checking values")
    print(f"|val - val_ref|: {(val - val_ref).abs()}\n")
    assert torch.allclose(val, val_ref)

    # Gradients
    val.backward()
    val_ref.backward()
    print("Checking gradients:")
    print(f"f: max(|grad|): {f.grad.abs().max()}\n")
    assert torch.allclose(f.grad, torch.zeros_like(f.grad))
    print(f"g: max(|grad - grad_ref|): {(g.grad - g_ref.grad).abs().max()}\n")
    print(f"h: max(|grad - grad_ref|): {(h.grad - h_ref.grad).abs().max()}\n")
    assert torch.allclose(f.grad, torch.zeros_like(f.grad))

```
Please let me know if there's anything I can add/change!