### PR TITLE
Re-enable CI for RKeOps on MacOS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,7 +119,7 @@ pipeline {
             echo 'Testing..'
               sh 'git submodule update --init'
               sh '''
-                 # bash rkeops/ci/run_ci.sh
+                 bash rkeops/ci/run_ci.sh
               '''
           }
         }

--- a/rkeops/ci/prepare_macos_ci.sh
+++ b/rkeops/ci/prepare_macos_ci.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+brew install r
+brew install libgit2
+brew install pandoc
+brew install qpdf


### PR DESCRIPTION
Fix #94 (when RKeOps CI pipeline is run on new MacOS VM, verson 10.15)