### PR TITLE
Fix LazyTensor.step documentation

### DIFF
--- a/pykeops/common/lazy_tensor.py
+++ b/pykeops/common/lazy_tensor.py
@@ -1368,7 +1368,7 @@ class GenericLazyTensor:
         Element-wise step function - a unary operation.
 
         ``x.step()`` returns a :class:`LazyTensor` that encodes, symbolically,
-        the element-wise sign of ``x``.
+        the element-wise step of ``x``.
         """
         return self.unary("Step")
 


### PR DESCRIPTION
Documentation for LazyTensor.step says "element-wise sign of x" instead of step.