### PR TITLE
Rkeops fix keops kernel and more

### DIFF
--- a/rkeops/DESCRIPTION
+++ b/rkeops/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: rkeops
 Type: Package
 Title: Kernel Operations on GPU or CPU, with Autodiff, without Memory Overflows
-Version: 1.4.2.2
-Date: 2021-02-17
+Version: 1.5
+Date: 2021-07-27
 Authors@R: c(
     person(given="Benjamin", family="Charlier", 
            comment="<http://imag.umontpellier.fr/~charlier/>", 

--- a/rkeops/R/generic-keops_grad.R
+++ b/rkeops/R/generic-keops_grad.R
@@ -19,7 +19,7 @@
 #' input operator.
 #' 
 #' To decide regarding which variable the input operator should be derived,
-#' you can specify its name or its position starting as 0 with the input 
+#' you can specify its name or its position starting at 0 with the input 
 #' parameter `var`. 
 #' @author Ghislain Durif
 #' @param operator a function returned by `keops_kernel` implementing a 
@@ -104,5 +104,5 @@ keops_grad <- function(operator, var) {
         stop("`var` input argument should be a text string or an integer.")
     }
     # define new op
-    return(keops_kernel(new_formula, env$args))
+    return(keops_kernel(new_formula, env$args, keops_grad_call = TRUE))
 }

--- a/rkeops/R/generic-keops_kernel.R
+++ b/rkeops/R/generic-keops_kernel.R
@@ -169,7 +169,7 @@ keops_kernel <- function(formula, args) {
         if(sum(str_length(names(input)) > 0) == length(input)) {
             # expected order
             expected_order <- env$var_aliases$var_name
-            # check if names are consistant
+            # check if names are consistent
             if(all(names(input) %in% expected_order))
                 if(any(names(input) != expected_order))
                     input <- input[expected_order]

--- a/rkeops/R/generic-keops_kernel.R
+++ b/rkeops/R/generic-keops_kernel.R
@@ -187,7 +187,7 @@ keops_kernel <- function(formula, args) {
         }
         
         ## dimension
-        nx <- 0
+        nx <- 1
         if("Vi" %in% env$var_aliases$var_type) {
             ind_Vi <- head(which(env$var_aliases$var_type == "Vi"), 1)
             dim_Vi <- dim(input[[ind_Vi]])
@@ -200,7 +200,7 @@ keops_kernel <- function(formula, args) {
             }
         }
         
-        ny <- 0
+        ny <- 1
         if("Vj" %in% env$var_aliases$var_type) {
             ind_Vj <- head(which(env$var_aliases$var_type == "Vj"), 1)
             dim_Vj <- dim(input[[ind_Vj]])

--- a/rkeops/man/keops_grad.Rd
+++ b/rkeops/man/keops_grad.Rd
@@ -44,7 +44,7 @@ to compile a new operator corresponding to the partial derivative of the
 input operator.
 
 To decide regarding which variable the input operator should be derived,
-you can specify its name or its position starting as 0 with the input
+you can specify its name or its position starting at 0 with the input
 parameter \code{var}.
 }
 \examples{

--- a/rkeops/man/keops_kernel.Rd
+++ b/rkeops/man/keops_kernel.Rd
@@ -4,12 +4,15 @@
 \alias{keops_kernel}
 \title{Defines a new operators}
 \usage{
-keops_kernel(formula, args)
+keops_kernel(formula, args, keops_grad_call = FALSE)
 }
 \arguments{
 \item{formula}{text string, an operator formula (see Details).}
 
 \item{args}{vector of text string, formula arguments (see Details).}
+
+\item{keops_grad_call}{boolean, for internal use only, do not modify this
+input value.}
 }
 \value{
 a function that can be used to compute the value of the formula
@@ -47,9 +50,9 @@ We use a list to avoid useless copies of data.
 argument passing is done by copy in R, it is better to copy a list of
 reference than the actual input data, especially for big matrices.
 
-You should be careful with the input dimension of your data, to correspond
-to the input dimension specified in \code{args} (see inner ou outer dimension in
-\code{browseVignettes("rkeops")}.
+You should be careful with the input dimension of your data, so that
+it correspond to the input dimension specified in \code{args}
+(see inner ou outer dimension in \code{browseVignettes("rkeops")}.
 
 It is possible to compute partial derivatives of user defined operators
 with the function \code{\link[=keops_grad]{keops_grad()}}.
@@ -97,9 +100,9 @@ res <- op(list(X,Y), inner_dim=0)
 # Defining a function that computes the convolution with a Gaussian kernel 
 # i.e. the sum over i of `e^(lambda * ||x_i - y_j||^2) * beta_j` where `x_i`, 
 # `y_j` and `beta_j` are 3d vectors, and `lambda` is a scalar parameter.
-op = keops_kernel(formula = "Sum_Reduction(Exp(lambda*SqNorm2(x-y))*beta, 1)",
-                 args = c("x=Vi(3)", "y=Vj(3)", 
-                          "beta=Vj(3)", "lambda=Pm(1)"))
+op = keops_kernel(
+    formula = "Sum_Reduction(Exp(lambda*SqNorm2(x-y))*beta, 1)",
+    args = c("x=Vi(3)", "y=Vj(3)", "beta=Vj(3)", "lambda=Pm(1)"))
 
 # data
 nx <- 10

--- a/rkeops/prebuild.R
+++ b/rkeops/prebuild.R
@@ -22,7 +22,7 @@ prebuild <- function() {
     # update Version
     command <- paste0("sed -i -e ",
                       "\"s/Version: .*/Version: $(cat ", 
-                      file.path(projdir, "version"), ")/\" ",
+                      file.path(projdir, "rkeops", "version"), ")/\" ",
                       filename)
     tmp <- system(command)
     # update Date

--- a/rkeops/tests/testthat/helper-3_generic.R
+++ b/rkeops/tests/testthat/helper-3_generic.R
@@ -16,13 +16,3 @@ check_args <- function(args, arg_order = NULL) {
                           "decltype(Pm(3,1)) lambda;")[arg_order],
                         collapse = ""))
 }
-
-# function to repeat check of keops_kernel
-run_op <- function(op, input, expected_res, inner_dim) {
-    # run
-    res <- tryCatch(op(input, inner_dim),
-                    error = function(e) {print(e); return(NULL)})
-    expect_false(is.null(res))
-    # check result
-    expect_true(sum(abs(res - expected_res)) < 1E-4)
-}

--- a/rkeops/version
+++ b/rkeops/version
@@ -1,1 +1,1 @@
-../version
+../keops_version


### PR DESCRIPTION
Concerning RKeOps:
- [x] Fix #182 issue with non-matrix to matrix conversion of operator input
- [x] Fix issue with default dimension of empty `Vi` or `Vj` (resp. `nx=1` or `ny=1` instead of 0)
- Fix typos in doc
- Improve tests of `keops_kernel` and `keops_grad` in RKeOps
- Use new version file called `keops_version`