### PR TITLE
Rename default branch to main

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -142,7 +142,7 @@ source_parsers = {
 #
 source_suffix = [".rst", ".md"]
 
-# The master toctree document.
+# The root toctree document.
 root_doc = "index"
 
 # General information about the project.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,7 +26,7 @@ sys.path.insert(0, os.path.abspath("sphinxext"))
 try:
     import pykeops
 except:
-    sys.path.insert(0, os.path.abspath(".."))
+    sys.path.insert(0, os.path.join(os.path.abspath(os.pardir), "pykeops"))
     import pykeops
 
 from pykeops import __version__
@@ -95,16 +95,16 @@ from sphinx_gallery.sorting import FileNameSortKey
 sphinx_gallery_conf = {
     # path to your examples scripts
     "examples_dirs": [
-        "../pykeops/tutorials",
-        "../pykeops/benchmarks",
-        "../pykeops/examples",
+        "../pykeops/pykeops/tutorials",
+        "../pykeops/pykeops/benchmarks",
+        "../pykeops/pykeops/examples",
     ],
     # path where to save gallery generated examples
     "gallery_dirs": ["_auto_tutorials", "_auto_benchmarks", "./_auto_examples"],
     # order of the Gallery
     "within_subsection_order": FileNameSortKey,
     # Add patterns
-    # 'filename_pattern': r'../pykeops/tutorials/*',
+    # 'filename_pattern': r'../pykeops/pykeops/tutorials/*',
 }
 
 # Generate the API documentation when building

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -143,7 +143,7 @@ source_parsers = {
 source_suffix = [".rst", ".md"]
 
 # The master toctree document.
-master_doc = "index"
+root_doc = "index"
 
 # General information about the project.
 project = "KeOps"
@@ -270,7 +270,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (
-        master_doc,
+        root_doc,
         "KeOps.tex",
         "KeOps Documentation",
         "Benjamin Charlier, Jean Feydy, Joan A. Glaunès",
@@ -283,7 +283,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "keops", "KeOps Documentation", [author], 1)]
+man_pages = [(root_doc, "keops", "KeOps Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -293,7 +293,7 @@ man_pages = [(master_doc, "keops", "KeOps Documentation", [author], 1)]
 #  dir menu entry, description, category)
 texinfo_documents = [
     (
-        master_doc,
+        root_doc,
         "KeOps",
         "KeOps Documentation",
         author,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -59,7 +59,7 @@ extensions = [
 def linkcode_resolve(domain, info):
     def find_source():
         # try to find the file and line number, based on code from numpy:
-        # https://github.com/numpy/numpy/blob/master/doc/source/conf.py#L286
+        # https://github.com/numpy/numpy/blob/main/doc/source/conf.py#L286
         obj = sys.modules[info["module"]]
         for part in info["fullname"].split("."):
             obj = getattr(obj, part)
@@ -78,7 +78,7 @@ def linkcode_resolve(domain, info):
     except Exception:
         filename = info["module"].replace(".", "/") + ".py"
 
-    return "https://github.com/getkeops/keops/tree/master/%s" % filename
+    return "https://github.com/getkeops/keops/tree/main/%s" % filename
 
 
 # def linkcode_resolve(domain, info):
@@ -88,7 +88,7 @@ def linkcode_resolve(domain, info):
 # if not info['module']:
 # return None
 # filename = get_full_modname(info['module'], info['fullname']).replace('.', '/')
-# return "https://github.com/getkeops/keops/tree/master/%s.py" % filename
+# return "https://github.com/getkeops/keops/tree/main/%s.py" % filename
 
 from sphinx_gallery.sorting import FileNameSortKey
 
@@ -214,7 +214,7 @@ html_context = {
     "display_github": True,  # Integrate Github
     "github_user": "getkeops",  # Username
     "github_repo": "keops",  # Repo name
-    "github_version": "master",  # Version
+    "github_version": "main",  # Version
     "conf_py_path": "/doc/",  # Path in the checkout to the docs root
 }
 # The name for this set of Sphinx documents.  If None, it defaults to

--- a/doc/engine/block_sparsity.rst
+++ b/doc/engine/block_sparsity.rst
@@ -144,7 +144,7 @@ This block-wise approach to sparse reductions may seem a bit too coarse,
 as some negligible coefficients get computed with little to no impact on
 the final result... But in practice, the **GPU speed-ups** on contiguous
 memory operations more than make up for it: implemented in the
-`GpuConv1D_ranges.cu <https://github.com/getkeops/keops/blob/master/keops/core/mapreduce/GpuConv1D_ranges.cu>`_ 
+`GpuConv1D_ranges.cu <https://github.com/getkeops/keops/blob/main/keops/core/mapreduce/GpuConv1D_ranges.cu>`_ 
 CUDA file, our block-sparse Map-Reduce scheme is
 the workhorse of the **multiscale Sinkhorn algorithm** showcased in
 the `GeomLoss library <https://www.kernel-operations.io/geomloss/>`_.

--- a/doc/engine/map_reduce_schemes.rst
+++ b/doc/engine/map_reduce_schemes.rst
@@ -5,7 +5,7 @@ Map-Reduce schemes
 The **most important piece of code** in the KeOps package is the
 one-dimensional, heavily templated Map-Reduce scheme that can be found
 in the 
-`GpuConv1D.cu <https://github.com/getkeops/keops/blob/master/keops/core/mapreduce/GpuConv1D.cu>`_ 
+`GpuConv1D.cu <https://github.com/getkeops/keops/blob/main/keops/core/mapreduce/GpuConv1D.cu>`_ 
 CUDA file. Used as a **default backend** by the
 :mod:`Genred` operator, this standard distributed algorithm relies on
 principles that are exposed in the reference 
@@ -195,7 +195,7 @@ tensors.
 Nevertheless, to provide cover for cases where the number of “indexing
 lines” :math:`\mathrm{M}` is much smaller than the size of the “reduction range”
 :math:`\mathrm{N}`, KeOps also implements a **2D Map-Reduce scheme** in the
-`GpuConv2D.cu <https://github.com/getkeops/keops/blob/master/keops/core/mapreduce/GpuConv2D.cu>`_ 
+`GpuConv2D.cu <https://github.com/getkeops/keops/blob/main/keops/core/mapreduce/GpuConv2D.cu>`_ 
 CUDA file. Assigning the
 :math:`\mathrm{K}`-by-:math:`\mathrm{K}` tiles of
 the computation plan **one-by-one to the CUDA blocks** – instead of

--- a/doc/engine/repository.rst
+++ b/doc/engine/repository.rst
@@ -3,17 +3,17 @@ Structure of the repository
 
 `KeOps repo <https://github.com/getkeops/keops>`_ structure may be summarized as follows:
 
--  The `pykeops/ <(https://github.com/getkeops/keops/tree/master/pykeops>`_ folder, 
-   with `common/ <https://github.com/getkeops/keops/tree/master/pykeops/common>`_, 
-   `numpy/ <https://github.com/getkeops/keops/tree/master/pykeops/numpy>`_ and 
-   `torch/ <https://github.com/getkeops/keops/tree/master/pykeops/torch>`_
+-  The `pykeops/ <(https://github.com/getkeops/keops/tree/main/pykeops>`_ folder, 
+   with `common/ <https://github.com/getkeops/keops/tree/main/pykeops/common>`_, 
+   `numpy/ <https://github.com/getkeops/keops/tree/main/pykeops/numpy>`_ and 
+   `torch/ <https://github.com/getkeops/keops/tree/main/pykeops/torch>`_
    subfolders contains our Python wrappers and relies on the
    fantastic `PyBind11 <https://pybind11.readthedocs.io/en/stable/>`_ library.
 
--  The `rkeops/ <https://github.com/getkeops/keops/tree/master/rkeops>`_
+-  The `rkeops/ <https://github.com/getkeops/keops/tree/main/rkeops>`_
    folder contains the R package sources deployed on CRAN.
 
--  The `keops/ <https://github.com/getkeops/keops/tree/master/keops>`_
+-  The `keops/ <https://github.com/getkeops/keops/tree/main/keops>`_
    folder contains the meta-programming engine written in Python. It may
    be loaded as a Python module. There is no dependencies except built-in
    functions.

--- a/doc/formulas/backpropagation.rst
+++ b/doc/formulas/backpropagation.rst
@@ -118,7 +118,7 @@ Bootstrapping derivatives of arbitrary order
 
 Applying these **commutation rules** between the differential operator
 :math:`\partial_\texttt{V}` and the Sum or Log-Sum-Exp reductions, the
-`pykeops/torch/generic/generic_red.py <https://github.com/getkeops/keops/blob/master/pykeops/torch/generic/generic_red.py>`_ 
+`pykeops/torch/generic/generic_red.py <https://github.com/getkeops/keops/blob/main/pykeops/torch/generic/generic_red.py>`_ 
 module provides full
 compatibility between KeOps :mod:`LazyTensors` and the 
 :mod:`torch.autograd`

--- a/doc/formulas/design_choices.rst
+++ b/doc/formulas/design_choices.rst
@@ -22,9 +22,9 @@ the relevant variables.
 Back in 2017, in early KeOps releases, this is how we first
 implemented the Gaussian kernel dot product and its derivatives of
 order 1 and 2 : with **explicit** 
-“`gaussian_dot.cu <https://github.com/getkeops/keops/blob/master/keops/specific/radial_kernels/cuda_conv.cx>`_”,
-“`gaussian_dot_grad_x.cu <https://github.com/getkeops/keops/blob/master/keops/specific/radial_kernels/cuda_grad1conv.cx>`_”, 
-“`gaussian_dot_grad_xx.cu <https://github.com/getkeops/keops/blob/master/keops/specific/radial_kernels/cuda_gradconv_xx.cx>`_” 
+“`gaussian_dot.cu <https://github.com/getkeops/keops/blob/main/keops/specific/radial_kernels/cuda_conv.cx>`_”,
+“`gaussian_dot_grad_x.cu <https://github.com/getkeops/keops/blob/main/keops/specific/radial_kernels/cuda_grad1conv.cx>`_”, 
+“`gaussian_dot_grad_xx.cu <https://github.com/getkeops/keops/blob/main/keops/specific/radial_kernels/cuda_gradconv_xx.cx>`_” 
 CUDA files.
 Once the basics are understood, **writing by hand** an *ad hoc* CUDA program
 for every specific type of operation is not too difficult.
@@ -82,7 +82,7 @@ Working with variadic templates
 To achieve our goals whilst abiding by these constraints, we chose to
 **rely on the power of modern C++/CUDA compilers**. Leveraging
 expressive **meta-programming instructions** that were introduced by the
-C++11 revision, the `keops/core/ <https://github.com/getkeops/keops/tree/master/keops/core>`_ folder effectively
+C++11 revision, the `keops/core/ <https://github.com/getkeops/keops/tree/main/keops/core>`_ folder effectively
 implements a small but robust math engine **within the C++ templating system**.
 
 Letting a general-purpose tool such as **nvcc** or **clang** handle the

--- a/doc/formulas/math_operations.rst
+++ b/doc/formulas/math_operations.rst
@@ -7,31 +7,31 @@ As detailed
 our parsing grammar for symbolic formulas is
 described in terms of **abstract C++ types** 
 implemented in the 
-`keops/core/formulas/*/*.h <https://github.com/getkeops/keops/tree/master/keops/core/formulas>`_
+`keops/core/formulas/*/*.h <https://github.com/getkeops/keops/tree/main/keops/core/formulas>`_
 headers. These files provide a **comprehensive list of mathematical
 operators** and rely on the primitives implemented in the
-`keops/core/pack <https://github.com/getkeops/keops/tree/master/keops/core/pack>`_ 
+`keops/core/pack <https://github.com/getkeops/keops/tree/main/keops/core/pack>`_ 
 and 
-`keops/core/autodiff <https://github.com/getkeops/keops/tree/master/keops/core/autodiff>`_ 
+`keops/core/autodiff <https://github.com/getkeops/keops/tree/main/keops/core/autodiff>`_ 
 subfolders: 
 abstract
-`unary <https://github.com/getkeops/keops/blob/master/keops/core/autodiff/UnaryOp.h>`_
+`unary <https://github.com/getkeops/keops/blob/main/keops/core/autodiff/UnaryOp.h>`_
 and 
-`binary <https://github.com/getkeops/keops/blob/master/keops/core/autodiff/BinaryOp.h>`_ 
+`binary <https://github.com/getkeops/keops/blob/main/keops/core/autodiff/BinaryOp.h>`_ 
 operators, 
-`tuples <https://github.com/getkeops/keops/blob/master/keops/core/pack/Pack.h>`_  of variables and parameters, 
-`variables <https://github.com/getkeops/keops/tree/master/keops/core/autodiff>`_, 
-`gradients <https://github.com/getkeops/keops/blob/master/keops/core/autodiff/Grad.h>`_.
+`tuples <https://github.com/getkeops/keops/blob/main/keops/core/pack/Pack.h>`_  of variables and parameters, 
+`variables <https://github.com/getkeops/keops/tree/main/keops/core/autodiff>`_, 
+`gradients <https://github.com/getkeops/keops/blob/main/keops/core/autodiff/Grad.h>`_.
 
 In practice
 -----------------
 
 To give a glimpse of **how KeOps works under the hood**, let us present
 a small excerpt from the 
-`formulas/maths/ <https://github.com/getkeops/keops/tree/master/keops/core/formulas/maths>`_ 
+`formulas/maths/ <https://github.com/getkeops/keops/tree/main/keops/core/formulas/maths>`_ 
 subfolder – the declaration
 of the :mod:`Log(...)` operator
-in the `Log.h <https://github.com/getkeops/keops/blob/master/keops/core/formulas/maths/Log.h>`_ 
+in the `Log.h <https://github.com/getkeops/keops/blob/main/keops/core/formulas/maths/Log.h>`_ 
 header:
 
 .. code-block:: cpp
@@ -70,7 +70,7 @@ As evidenced here, the implementation of a new operator goes through
 
 #. The **declaration** of a new operation as an instance of the abstract
    :mod:`UnaryOp` or :mod:`BinaryOp` templates. These are defined in the
-   `keops/core/autodiff <https://github.com/getkeops/keops/tree/master/keops/core/autodiff>`_ 
+   `keops/core/autodiff <https://github.com/getkeops/keops/tree/main/keops/core/autodiff>`_ 
    folder with a set of standard methods and
    attributes. The operand :mod:`F` of :mod:`Log<F>` is an arbitrary formula,
    **recursively encoded as a templated structure**.
@@ -140,7 +140,7 @@ As evidenced here, the implementation of a new operator goes through
 #. **Declare a convenient alias for the operation.**
    This arcane formulation relies on classes
    defined in the
-   `keops/core/pre_headers.h <https://github.com/getkeops/keops/blob/master/keops/core/pre_headers.h>`_
+   `keops/core/pre_headers.h <https://github.com/getkeops/keops/blob/main/keops/core/pre_headers.h>`_
    header.
 
 Contributing with a new operation
@@ -151,19 +151,19 @@ operators**, injecting their C++ code within the KeOps
 Map-Reduce kernels. Doing so is now relatively easy: 
 having implemented a
 custom instance of the :mod:`UnaryOp` or :mod:`BinaryOp` templates in 
-a new `keops/core/formulas/*/*.h <https://github.com/getkeops/keops/tree/master/keops/core/formulas>`_ header, 
+a new `keops/core/formulas/*/*.h <https://github.com/getkeops/keops/tree/main/keops/core/formulas>`_ header, 
 contributors should simply
 remember to add their file to the
-`list of KeOps includes <https://github.com/getkeops/keops/blob/master/keops/keops_includes.h>`_
+`list of KeOps includes <https://github.com/getkeops/keops/blob/main/keops/keops_includes.h>`_
 and write a LazyTensor method in the
-`pykeops/common/lazy_tensor.py <https://github.com/getkeops/keops/blob/master/pykeops/common/lazy_tensor.py>`_ 
+`pykeops/common/lazy_tensor.py <https://github.com/getkeops/keops/blob/main/pykeops/common/lazy_tensor.py>`_ 
 module. 
 
 To **get merged** in the 
 `main KeOps repository <https://github.com/getkeops/keops>`_, 
 which is hosted on GitHub, writing a simple 
 **unit test** in the 
-`pykeops/test/ <https://github.com/getkeops/keops/tree/master/pykeops/test>`_ 
+`pykeops/test/ <https://github.com/getkeops/keops/tree/main/pykeops/test>`_ 
 folder and an **adequate description** in the
 **pull request** should then be enough.
 

--- a/doc/formulas/reductions.rst
+++ b/doc/formulas/reductions.rst
@@ -4,7 +4,7 @@ Reductions
 
 **Following the same design principles**, :math:`\operatorname{Reduction}`
 operators are implemented in the 
-`keops/core/reductions/*.h <https://github.com/getkeops/keops/tree/master/keops/core/reductions>`_ headers.
+`keops/core/reductions/*.h <https://github.com/getkeops/keops/tree/main/keops/core/reductions>`_ headers.
 Taking as input an arbitrary symbolic formula :mod:`F`, 
 :mod:`Reduction<F>`
 templates encode generic Map-Reduce schemes 
@@ -14,7 +14,7 @@ Summation
 --------------
 
 In the case of the simple **Sum** reduction 
-(`Sum_Reduction.h <https://github.com/getkeops/keops/blob/master/keops/core/reductions/Sum_Reduction.h>`_ header), 
+(`Sum_Reduction.h <https://github.com/getkeops/keops/blob/main/keops/core/reductions/Sum_Reduction.h>`_ header), 
 these can be described as:
 
 #. An :mod:`InitializeReduction` method, which **fills up the running buffer**
@@ -45,7 +45,7 @@ The online Log-Sum-Exp trick
 --------------------------------
 
 More interestingly, the 
-`Max_SumShiftExp_Reduction.h <https://github.com/getkeops/keops/blob/master/keops/core/reductions/Max_SumShiftExp_Reduction.h>`_ 
+`Max_SumShiftExp_Reduction.h <https://github.com/getkeops/keops/blob/main/keops/core/reductions/Max_SumShiftExp_Reduction.h>`_ 
 header implements an
 **online version** of the well-known 
 `Log-Sum-Exp trick <https://en.wikipedia.org/wiki/LogSumExp>`_: 
@@ -67,7 +67,7 @@ of maximum likelihood estimators and entropic Optimal Transport solvers
 
 Merging the content of our **C++ header** and of the 
 **Python post-processing step** implemented in 
-`pykeops/common/operations.py <https://github.com/getkeops/keops/blob/master/pykeops/common/operations.py>`_,
+`pykeops/common/operations.py <https://github.com/getkeops/keops/blob/main/pykeops/common/operations.py>`_,
 assuming that :math:`F_{i,j} = F(p^1,\dots,x^1_i,\dots,y^1_j,\dots)` is
 a scalar quantity, we may describe its behaviour as follows:
 

--- a/doc/introduction/contributing.rst
+++ b/doc/introduction/contributing.rst
@@ -47,8 +47,8 @@ you may help us to develop KeOps as follows:
    its flexibility.
    In order to add a new example or tutorial to this website, 
    you should simply write a new Python file in
-   the `pykeops/tutorials <https://github.com/getkeops/keops/tree/master/pykeops/tutorials>`_
-   or `pykeops/examples <https://github.com/getkeops/keops/tree/master/pykeops/examples>`_
+   the `pykeops/tutorials <https://github.com/getkeops/keops/tree/main/pykeops/tutorials>`_
+   or `pykeops/examples <https://github.com/getkeops/keops/tree/main/pykeops/examples>`_
    folders with 
    `detailed comments <https://sphinx-gallery.github.io/stable/index.html>`_
    and submit your `pull request <https://github.com/getkeops/keops/pulls>`_.

--- a/doc/introduction/road-map.rst
+++ b/doc/introduction/road-map.rst
@@ -227,5 +227,5 @@ but we'd be happy to diversify the team!
 Changelog
 ---------
 
-Our `Changelog <https://github.com/getkeops/keops/blob/master/CHANGELOG.md>`_
+Our `Changelog <https://github.com/getkeops/keops/blob/main/CHANGELOG.md>`_
 can be found on the `KeOps Github repository <https://github.com/getkeops/keops/>`_.

--- a/doc/matlab/generic-syntax.rst
+++ b/doc/matlab/generic-syntax.rst
@@ -1,9 +1,9 @@
 Matlab API
 ==========
 
-The example described below is implemented in the example Matlab script `script_GenericSyntax.m <https://github.com/getkeops/keops/blob/master/keopslab/examples/script_GenericSyntax.m>`_ located in directory ``keopslab/examples``.
+The example described below is implemented in the example Matlab script `script_GenericSyntax.m <https://github.com/getkeops/keops/blob/main/keopslab/examples/script_GenericSyntax.m>`_ located in directory ``keopslab/examples``.
 
-The Matlab bindings provide a function `keops_kernel <https://github.com/getkeops/keops/blob/master/keopslab/generic/keops_kernel.m>`_ which can be used to define the corresponding convolution operations. Following the previous example, one may write
+The Matlab bindings provide a function `keops_kernel <https://github.com/getkeops/keops/blob/main/keopslab/generic/keops_kernel.m>`_ which can be used to define the corresponding convolution operations. Following the previous example, one may write
 
 .. code-block:: matlab
      
@@ -16,7 +16,7 @@ which defines a Matlab function handler ``f`` which can be used to perform a sum
     c = f(p,a,x,y);
 
 
-where ``p``, ``a``, ``x``, ``y`` must be arrays with compatible dimensions as previously explained. A gradient function `keops_grad <https://github.com/getkeops/keops/blob/master/keopslab/generic/keops_grad.m>`_ is also provided. For example, to get the gradient with respect to ``y`` of the previously defined function ``f``, one needs to write:
+where ``p``, ``a``, ``x``, ``y`` must be arrays with compatible dimensions as previously explained. A gradient function `keops_grad <https://github.com/getkeops/keops/blob/main/keopslab/generic/keops_grad.m>`_ is also provided. For example, to get the gradient with respect to ``y`` of the previously defined function ``f``, one needs to write:
 
 .. code-block:: matlab
     

--- a/doc/python/generic-reduction.rst
+++ b/doc/python/generic-reduction.rst
@@ -4,8 +4,8 @@ Math-friendly syntax
 The :class:`Genred` operator provides a pythonic interface for the KeOps library.
 To let users code with maximum efficiency, we also propose
 some math-friendly **syntactic sugar** for 
-`NumPy <https://github.com/getkeops/keops/blob/master/pykeops/numpy/generic/generic_ops.py>`_ and
-`PyTorch <https://github.com/getkeops/keops/blob/master/pykeops/torch/generic/generic_ops.py>`_:
+`NumPy <https://github.com/getkeops/keops/blob/main/pykeops/numpy/generic/generic_ops.py>`_ and
+`PyTorch <https://github.com/getkeops/keops/blob/main/pykeops/torch/generic/generic_ops.py>`_:
 
 
 .. code-block:: python

--- a/doc/python/installation.rst
+++ b/doc/python/installation.rst
@@ -52,8 +52,8 @@ of KeOps is to use `some advanced pip syntax <https://pip.pypa.io/en/stable/refe
 
 .. code-block:: bash
 
-    pip install git+https://github.com/getkeops/keops.git@master#subdirectory=keopscore
-    pip install git+https://github.com/getkeops/keops.git@master#subdirectory=pykeops
+    pip install git+https://github.com/getkeops/keops.git@main#subdirectory=keopscore
+    pip install git+https://github.com/getkeops/keops.git@main#subdirectory=pykeops
 
 
 Alternatively, you may:

--- a/pykeops/pykeops/benchmarks/README.txt
+++ b/pykeops/pykeops/benchmarks/README.txt
@@ -7,7 +7,7 @@ These benchmarks showcase the performances of the KeOps routines as the number o
 Comparison with other related projects
 --------------------------------------
 
-KeOps is **fast**! You may find `here <https://github.com/getkeops/keops/tree/master/benchmarks>`_ a benchmark that compare the performances of pyKeOps with other related projects.
+KeOps is **fast**! You may find `here <https://github.com/getkeops/keops/tree/main/benchmarks>`_ a benchmark that compare the performances of pyKeOps with other related projects.
 
 pyKeOps benchmarks
 ------------------

--- a/pykeops/pykeops/numpy/generic/generic_red.py
+++ b/pykeops/pykeops/numpy/generic/generic_red.py
@@ -208,8 +208,8 @@ class Genred:
 
                     - ``"auto"`` (default): let KeOps decide which backend is best suited to your data, based on the tensors' shapes. ``"GPU_1D"`` will be chosen in most cases.
                     - ``"CPU"``: use a simple C++ ``for`` loop on a single CPU core.
-                    - ``"GPU_1D"``: use a `simple multithreading scheme <https://github.com/getkeops/keops/blob/master/keops/core/GpuConv1D.cu>`_ on the GPU - basically, one thread per value of the output index.
-                    - ``"GPU_2D"``: use a more sophisticated `2D parallelization scheme <https://github.com/getkeops/keops/blob/master/keops/core/GpuConv2D.cu>`_ on the GPU.
+                    - ``"GPU_1D"``: use a `simple multithreading scheme <https://github.com/getkeops/keops/blob/main/keops/core/GpuConv1D.cu>`_ on the GPU - basically, one thread per value of the output index.
+                    - ``"GPU_2D"``: use a more sophisticated `2D parallelization scheme <https://github.com/getkeops/keops/blob/main/keops/core/GpuConv2D.cu>`_ on the GPU.
                     - ``"GPU"``: let KeOps decide which one of the ``"GPU_1D"`` or the ``"GPU_2D"`` scheme will run faster on the given input.
 
             device_id (int, default=-1): Specifies the GPU that should be used

--- a/pykeops/pykeops/torch/generic/generic_red.py
+++ b/pykeops/pykeops/torch/generic/generic_red.py
@@ -517,8 +517,8 @@ class Genred:
 
                     - ``"auto"`` (default): let KeOps decide which backend is best suited to your data, based on the tensors' shapes. ``"GPU_1D"`` will be chosen in most cases.
                     - ``"CPU"``: use a simple C++ ``for`` loop on a single CPU core.
-                    - ``"GPU_1D"``: use a `simple multithreading scheme <https://github.com/getkeops/keops/blob/master/keops/core/GpuConv1D.cu>`_ on the GPU - basically, one thread per value of the output index.
-                    - ``"GPU_2D"``: use a more sophisticated `2D parallelization scheme <https://github.com/getkeops/keops/blob/master/keops/core/GpuConv2D.cu>`_ on the GPU.
+                    - ``"GPU_1D"``: use a `simple multithreading scheme <https://github.com/getkeops/keops/blob/main/keops/core/GpuConv1D.cu>`_ on the GPU - basically, one thread per value of the output index.
+                    - ``"GPU_2D"``: use a more sophisticated `2D parallelization scheme <https://github.com/getkeops/keops/blob/main/keops/core/GpuConv2D.cu>`_ on the GPU.
                     - ``"GPU"``: let KeOps decide which one of the ``"GPU_1D"`` or the ``"GPU_2D"`` scheme will run faster on the given input.
 
             device_id (int, default=-1): Specifies the GPU that should be used

--- a/pykeops/pykeops/tutorials/a_LazyTensors/plot_lazytensors_a.py
+++ b/pykeops/pykeops/tutorials/a_LazyTensors/plot_lazytensors_a.py
@@ -127,7 +127,7 @@ print(D_ij)
 #
 # We can then perform a :meth:`pykeops.torch.LazyTensor.argmin` reduction with
 # an efficient Map-Reduce scheme, implemented
-# as a `templated CUDA kernel <https://github.com/getkeops/keops/blob/master/keops/core/GpuConv1D.cu>`_ around
+# as a `templated CUDA kernel <https://github.com/getkeops/keops/blob/main/keops/core/GpuConv1D.cu>`_ around
 # our custom formula.
 # As evidenced by our :doc:`benchmarks <../../_auto_benchmarks/index>`,
 # the KeOps routines have a **linear memory footprint**

--- a/pykeops/pykeops/tutorials/a_LazyTensors/plot_lazytensors_b.py
+++ b/pykeops/pykeops/tutorials/a_LazyTensors/plot_lazytensors_b.py
@@ -190,4 +190,4 @@ print("g_i is now a {} of shape {}.".format(type(g_i), g_i.shape))
 #   To solve generic systems, you could either
 #   :doc:`interface KeOps with the routines of the SciPy package <../backends/plot_scipy>`
 #   or implement your own solver, mimicking our
-#   `reference implementation. <https://github.com/getkeops/keops/blob/master/pykeops/common/operations.py>`_
+#   `reference implementation. <https://github.com/getkeops/keops/blob/main/pykeops/common/operations.py>`_

--- a/pykeops/pykeops/tutorials/backends/plot_gpytorch.py
+++ b/pykeops/pykeops/tutorials/backends/plot_gpytorch.py
@@ -25,7 +25,7 @@ if you encounter any unexpected behavior with this experimental KeOps-GPytorch i
 
 .. note::
     The GPytorch team has now integrated 
-    `explicit KeOps kernels <https://github.com/cornellius-gp/gpytorch/tree/master/gpytorch/kernels/keops>`_ within
+    `explicit KeOps kernels <https://github.com/cornellius-gp/gpytorch/tree/main/gpytorch/kernels/keops>`_ within
     their repository: they are documented
     `in this tutorial <https://docs.gpytorch.ai/en/v1.1.1/examples/02_Scalable_Exact_GPs/KeOps_GP_Regression.html>`_ and make the handcrafted example below
     somewhat obsolete. Nevertheless, we keep this page

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 ---------------------------------------------------------------------------------
 
-[![Build status](https://ci.inria.fr/keops/buildStatus/icon?job=KeOps_ci%2Fmaster)](https://ci.inria.fr/keops/job/KeOps_ci/job/master/)
+[![Build status](https://ci.inria.fr/keops/buildStatus/icon?job=KeOps_ci%2Fmain)](https://ci.inria.fr/keops/job/KeOps_ci/job/main/)
 [![PyPI version](https://img.shields.io/pypi/v/pykeops?color=blue)](https://pypi.org/project/pykeops/)
 [![PyPI downloads](https://pepy.tech/badge/pykeops?color=green)](https://pypi.org/project/pykeops/)
 [![CRAN version](https://img.shields.io/cran/v/rkeops?color=yellowgreen)](https://cran.r-project.org/web/packages/rkeops/index.html)

--- a/rkeops/doc/introduction_to_rkeops.rst
+++ b/rkeops/doc/introduction_to_rkeops.rst
@@ -30,7 +30,7 @@ Introduction to RKeOps
 -  URL: https://www.kernel-operations.io/
 -  Source: https://github.com/getkeops/keops
 -  Licence and Copyright: see
-   https://github.com/getkeops/keops/blob/master/licence.txt
+   https://github.com/getkeops/keops/blob/main/licence.txt
 
 .. raw:: html
 

--- a/rkeops/vignettes/introduction_to_rkeops.Rmd
+++ b/rkeops/vignettes/introduction_to_rkeops.Rmd
@@ -24,7 +24,7 @@ knitr::opts_chunk$set(
 
 * URL: <https://www.kernel-operations.io/>
 * Source: <https://github.com/getkeops/keops>
-* Licence and Copyright: see <https://github.com/getkeops/keops/blob/master/licence.txt>
+* Licence and Copyright: see <https://github.com/getkeops/keops/blob/main/licence.txt>
 
 # Authors
 


### PR DESCRIPTION
All mention to default branch should have been corrected, and side effects should be contained.

Note on the side: fix the doc building after reorganization of python package in dedicated sub-directories in PR #222