### PR TITLE
Compile v2.1 on windows with vs2019 and cuda11.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.idea*
 *~
 *.swp
+.vs
 
 # virtual env
 *venv*

--- a/keopscore/keopscore/__init__.py
+++ b/keopscore/keopscore/__init__.py
@@ -11,6 +11,10 @@ here = path.abspath(path.dirname(__file__))
 with open(os.path.join(here, "keops_version"), encoding="utf-8") as v:
     __version__ = v.read().rstrip()
 
+if __version__.startswith('../'):
+    with open(os.path.join(here, __version__), encoding="utf-8") as v:
+        __version__ = v.read().rstrip()
+
 from .config.config import set_build_folder, get_build_folder
 from .utils.code_gen_utils import clean_keops
 

--- a/keopscore/keopscore/binders/nvrtc/CMakeLists.txt
+++ b/keopscore/keopscore/binders/nvrtc/CMakeLists.txt
@@ -1,0 +1,55 @@
+cmake_minimum_required(VERSION 3.12.0)
+
+set(CMAKE_BUILD_TYPE "Release")
+set(CMAKE_CXX_FLAGS_DEBUG "-g")
+set(CUDA_NVCC_FLAGS "--expt-relaxed-constexpr")
+
+# add_compile_definitions(IGL_STATIC_LIBRARY)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+project(NVRTC_JIT)
+
+#################### macro ####################
+add_definitions(-DARCHTAG=\"sm\")
+add_definitions(-DnvrtcGetTARGET=nvrtcGetCUBIN)
+add_definitions(-DnvrtcGetTARGETSize=nvrtcGetCUBINSize)
+
+#################### dependency ####################
+# cuda
+find_package(CUDA REQUIRED)
+set(CUDA_ARCH_BIN "86" CACHE STRING "Specify 'real' GPU arch to build binaries for, BIN(PTX) format is supported. Example: 1.3 2.1(1.3) or 13 21(13)")
+set(CUDA_ARCH_PTX "86" CACHE STRING "Specify 'virtual' PTX arch to build PTX intermediate code for. Example: 1.0 1.2 or 10 12")
+set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -ccbin g++ -O3) # -std=c++11  -Xptxas -g -allow-expensive-optimizations=true
+
+include_directories(${CUDA_INCLUDE_DIRS})
+message("CUDA_CUDART_LIBRARY = ${CUDA_CUDART_LIBRARY}")
+message("CUDA_LIBRARIES = ${CUDA_LIBRARIES}")
+message("CUDA_TOOLKIT_ROOT_DIR = ${CUDA_TOOLKIT_ROOT_DIR}")
+message("set nvrtc path = ${CUDA_TOOLKIT_ROOT_DIR}/lib/x64")
+link_directories(${CUDA_TOOLKIT_ROOT_DIR}/lib/x64)
+
+#################### src ####################
+# include
+include_directories(
+    "${CMAKE_CURRENT_SOURCE_DIR}/"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../"
+)
+
+file(GLOB SOURCES
+    "${CMAKE_CURRENT_SOURCE_DIR}/nvrtc_jit.cpp"
+)
+
+#################### compile ####################
+
+############################################################
+# target library
+add_library(nvrtc_jit SHARED ${SOURCES})
+target_link_libraries(nvrtc_jit
+    ${CUDA_CUDART_LIBRARY}
+    ${CUDA_LIBRARIES}
+    nvrtc
+    cuda
+)
+

--- a/keopscore/keopscore/binders/nvrtc/compile-win64.bat
+++ b/keopscore/keopscore/binders/nvrtc/compile-win64.bat
@@ -1,0 +1,48 @@
+@echo off
+set PWD=%~dp0
+set BUILD_DIR=%PWD%build
+echo %BUILD_DIR%
+
+if (%1) NEQ () (
+  set VCVARS64=%1
+)
+if (%2) NEQ () (
+  set PYBIND11_DIR=%2
+)
+
+if ((%VCVARS64%) == ()) (
+  echo "VCVARS64 not set, please add environ variable to vcvars64.bat"
+  set VCVARS64="C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+)
+if ((%VCVARS64%) == ("")) (
+  echo "VCVARS64 not set, please add environ variable to vcvars64.bat"
+  set VCVARS64="C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+)
+
+REM python -m pybind11 --cmakedir
+REM C:\ProgramData\Anaconda3\envs\pt1.11_cu11.3\lib\site-packages\pybind11\share\cmake\pybind11
+if (%PYBIND11_DIR%)==() (
+  set PYBIND11_DIR="C:\ProgramData\Anaconda3\envs\pt1.11_cu11.3\lib\site-packages\pybind11\share\cmake\pybind11"
+)
+if (%PYBIND11_DIR%)==("") (
+  set PYBIND11_DIR="C:\ProgramData\Anaconda3\envs\pt1.11_cu11.3\lib\site-packages\pybind11\share\cmake\pybind11"
+)
+
+echo --------------------------------------------------
+echo User defined path:
+echo VCVARS64 = %VCVARS64%
+echo PYBIND11_DIR = %PYBIND11_DIR%
+echo --------------------------------------------------
+
+REM enable vs
+call %VCVARS64%
+
+REM cmake
+cd /D %BUILD_DIR%
+
+cmake ../ -G Ninja -Dpybind11_DIR=%PYBIND11_DIR%
+
+REM build
+ninja -v
+
+REM pause

--- a/keopscore/keopscore/binders/nvrtc/nvrtc_jit.cpp
+++ b/keopscore/keopscore/binders/nvrtc/nvrtc_jit.cpp
@@ -16,6 +16,12 @@
 #define C_CONTIGUOUS 1
 #define USE_HALF 0
 
+#ifdef _WIN32
+#define DLL_EXPORT extern "C" __declspec(dllexport)
+#else
+#define DLL_EXPORT extern "C"
+#endif
+
 #include "include/Sizes.h"
 #include "include/Ranges.h"
 #include "include/utils_pe.h"
@@ -25,8 +31,8 @@
 #include "include/CudaSizes.h"
 #include <cuda_fp16.h>
 
-
-extern "C" int Compile(const char *target_file_name, const char *cu_code, int use_half, int device_id,
+DLL_EXPORT
+int Compile(const char *target_file_name, const char *cu_code, int use_half, int device_id,
                        const char *cuda_include_path) {
 
     nvrtcProgram prog;

--- a/keopscore/keopscore/config/config.py
+++ b/keopscore/keopscore/config/config.py
@@ -87,23 +87,72 @@ set_build_folder(read_save_file=True, write_save_file=False, reset_all=False)
 def get_build_folder():
     return _build_path
 
-
-jit_binary = join(_build_path, "keops_nvrtc.so")
+if os.name == 'nt':
+    jit_binary = join(_build_path, "keops_nvrtc.dll")
+else:
+    jit_binary = join(_build_path, "keops_nvrtc.so")
 
 # Compiler
 cxx_compiler = os.getenv("CXX")
 if cxx_compiler is None:
-    cxx_compiler = "g++"
-if shutil.which(cxx_compiler) is None:
-    KeOps_Warning(
-        """
-    The default C++ compiler could not be found on your system.
-    You need to either define the CXX environment variable or a symlink to the g++ command.
-    For example if g++-8 is the command you can do
-      import os
-      os.environ['CXX'] = 'g++-8'
-    """
-    )
+    if os.name =='nt':
+        cxx_compiler = "cl.exe"
+    else:
+        cxx_compiler = "g++"
+        if shutil.which(cxx_compiler) is None:
+            KeOps_Warning(
+                """
+            The default C++ compiler could not be found on your system.
+            You need to either define the CXX environment variable or a symlink to the g++ command.
+            For example if g++-8 is the command you can do
+                import os
+                os.environ['CXX'] = 'g++-8'
+            """
+            )
+
+# get cuda libs
+# os.environ['libcuda'] = 'nvcuda'
+# os.environ['libnvrtc'] = 'nvrtc-builtins64_113'
+# os.environ['libcudart'] = 'cudart64_110'
+def get_compiler_library(lib_key):
+    if lib_key == 'libcuda':
+        if 'libcuda' in os.environ:
+            return os.environ['libcuda']
+        else:
+            if os.name =='nt':
+                return 'nvcuda'
+            else:
+                return 'cuda'
+
+    if lib_key == 'libnvrtc':
+        if 'libnvrtc' in os.environ:
+            return os.environ['libnvrtc']
+        else:
+            if os.name =='nt':
+                # nvrtc in windows depends on cuda version
+                # e.g. 'nvrtc-builtins64_113' is for cuda '11.3'
+                import torch
+                cuda_ver = torch.version.cuda
+                nvrtc_name = 'nvrtc-builtins64_' + cuda_ver.replace('.', '')
+                return nvrtc_name
+            else:
+                return 'nvrtc'
+
+    if lib_key == 'libcudart':
+        if 'libcudart' in os.environ:
+            return os.environ['libcudart']
+        else:
+            if os.name =='nt':
+                # nvrtc in windows depends on cuda major version
+                # e.g. 'cudart64_110' is for cuda '11.x'
+                import torch
+                cuda_ver = torch.version.cuda
+                nvrtc_name = 'cudart64_' + cuda_ver.split('.')[0] + '0'
+                return nvrtc_name
+            else:
+                return 'nvrtc'
+
+    return None
 
 
 compile_options = " -shared -fPIC -O3 -std=c++11"
@@ -172,7 +221,31 @@ cpp_flags += " -I" + bindings_source_dir
 
 from keopscore.utils.gpu_utils import get_gpu_props
 
-cuda_dependencies = ["cuda", "nvrtc"]
+libcuda = get_compiler_library('libcuda')
+libnvrtc = get_compiler_library('libnvrtc')
+libcudart = get_compiler_library('libcudart')
+
+if os.name =='nt':
+    if libcuda == 'cuda':
+        KeOps_Warning(
+            "'cuda' changed to 'nvcuda' in Windows. Please set os.environ['libcuda'] if not working."
+        )
+        libcuda = 'nvcuda'
+
+    if libnvrtc == 'nvrtc':
+        KeOps_Warning(
+            "'nvrtc' in Windows is version related. Please set os.environ['nvrtc'], e.g. 'nvrtc-builtins64_113'."
+        )
+        libnvrtc = 'nvrtc-builtins64_113'
+
+    if libcudart == 'cudart':
+        KeOps_Warning(
+            "'cudart' in Windows is version related. Please set os.environ['cudart'], e.g. 'cudart64_110'."
+        )
+        libcudart = 'cudart64_110'
+
+cuda_dependencies = [libcuda, libnvrtc]
+
 if all([find_library(lib) for lib in cuda_dependencies]):
     # N.B. calling get_gpu_props issues a warning if cuda is not available, so we do not add another warning here
     cuda_available = get_gpu_props()[0] > 0
@@ -201,12 +274,12 @@ if use_cuda:
     cuda_version = get_cuda_version()
     nvrtc_flags = (
         compile_options
-        + f" -fpermissive -L{libcuda_folder} -L{libnvrtc_folder} -lcuda -lnvrtc"
+        + f' -fpermissive -L"{libcuda_folder}" -L"{libnvrtc_folder}" -lcuda -lnvrtc'
     )
-    nvrtc_include = " -I" + bindings_source_dir
+    nvrtc_include = f' -I"{bindings_source_dir}"'
     cuda_include_path = get_cuda_include_path()
     if cuda_include_path:
-        nvrtc_include += " -I" + cuda_include_path
+        nvrtc_include += f' -I"{cuda_include_path}"'
     jit_source_file = join(base_dir_path, "binders", "nvrtc", "keops_nvrtc.cpp")
     jit_source_header = join(base_dir_path, "binders", "nvrtc", "keops_nvrtc.h")
 else:
@@ -227,7 +300,7 @@ def init_cudalibs():
     if not keopscore.config.config.init_cudalibs_flag:
         # we load some libraries that need to be linked with KeOps code
         # This is to avoid "undefined symbols" errors.
-        CDLL(find_library("nvrtc"), mode=RTLD_GLOBAL)
-        CDLL(find_library("cuda"), mode=RTLD_GLOBAL)
-        CDLL(find_library("cudart"), mode=RTLD_GLOBAL)
+        CDLL(find_library(libnvrtc), mode=RTLD_GLOBAL)
+        CDLL(find_library(libcuda), mode=RTLD_GLOBAL)
+        CDLL(find_library(libcudart), mode=RTLD_GLOBAL)
         keopscore.config.config.init_cudalibs_flag = True

--- a/keopscore/keopscore/include/utils_pe.h
+++ b/keopscore/keopscore/include/utils_pe.h
@@ -72,7 +72,7 @@ load_args_FromHost(CUdeviceptr &p_data, TYPE *out, TYPE *&out_d, int nargs,
                    TYPE **arg, TYPE **&arg_d,
                    const std::vector< std::vector< int > > &argshape,
                    int sizeout) {
-    int sizes[nargs];
+    std::vector<int> sizes(nargs);
     int totsize = sizeout;
     for (int k = 0; k < nargs; k++) {
         sizes[k] = std::accumulate(argshape[k].begin(), argshape[k].end(), 1, std::multiplies< int >());
@@ -85,7 +85,7 @@ load_args_FromHost(CUdeviceptr &p_data, TYPE *out, TYPE *&out_d, int nargs,
     TYPE *dataloc = (TYPE *) (arg_d + nargs);
 
     // host array of pointers to device data
-    TYPE *ph[nargs];
+    std::vector<TYPE *> ph(nargs);
 
     out_d = dataloc;
     dataloc += sizeout;
@@ -96,5 +96,5 @@ load_args_FromHost(CUdeviceptr &p_data, TYPE *out, TYPE *&out_d, int nargs,
     }
 
     // copy array of pointers
-    CUDA_SAFE_CALL(cuMemcpyHtoD((CUdeviceptr) arg_d, ph, nargs * sizeof(TYPE *)));
+    CUDA_SAFE_CALL(cuMemcpyHtoD((CUdeviceptr) arg_d, ph.data(), nargs * sizeof(TYPE *)));
 }

--- a/keopscore/keopscore/utils/gpu_utils.py
+++ b/keopscore/keopscore/utils/gpu_utils.py
@@ -8,7 +8,7 @@ from keopscore.utils.misc_utils import (
     find_library_abspath,
     KeOps_OS_Run,
 )
-from keopscore.config.config import cxx_compiler, get_build_folder
+from keopscore.config.config import cxx_compiler, get_build_folder, get_compiler_library
 import os
 from os.path import join
 
@@ -17,8 +17,11 @@ CUDA_SUCCESS = 0
 CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK = 1
 CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK = 8
 
-libcuda_folder = os.path.dirname(find_library_abspath("cuda"))
-libnvrtc_folder = os.path.dirname(find_library_abspath("nvrtc"))
+libcuda = get_compiler_library('libcuda')
+libnvrtc = get_compiler_library('libnvrtc')
+libcudart = get_compiler_library('libcudart')
+libcuda_folder = os.path.dirname(find_library_abspath(libcuda))
+libnvrtc_folder = os.path.dirname(find_library_abspath(libnvrtc))
 
 
 def get_cuda_include_path():
@@ -122,7 +125,7 @@ def cuda_include_fp16_path():
 
 
 def get_cuda_version(out_type="single_value"):
-    cuda = ctypes.CDLL(find_library("cudart"))
+    cuda = ctypes.CDLL(find_library(libcudart))
     cuda_version = ctypes.c_int()
     cuda.cudaRuntimeGetVersion(ctypes.byref(cuda_version))
     cuda_version = int(cuda_version.value)
@@ -143,7 +146,7 @@ def get_gpu_props():
     Adapted from https://gist.github.com/f0k/0d6431e3faa60bffc788f8b4daa029b1
     credit: Jan Schlüter
     """
-    cuda = ctypes.CDLL(find_library("cuda"))
+    cuda = ctypes.CDLL(find_library(libcuda))
 
     nGpus = ctypes.c_int()
     error_str = ctypes.c_char_p()

--- a/keopscore/keopscore/utils/misc_utils.py
+++ b/keopscore/keopscore/utils/misc_utils.py
@@ -4,7 +4,6 @@
 
 import keopscore
 
-
 def KeOps_Message(message, use_tag=True, **kwargs):
     if keopscore.verbose:
         tag = "[KeOps] " if use_tag else ""
@@ -33,12 +32,16 @@ def KeOps_OS_Run(command):
 
     python_version = sys.version_info
     if python_version >= (3, 7):
-        import subprocess
+        import subprocess, os
 
         out = subprocess.run(command, shell=True, capture_output=True)
         if out.stderr != b"":
-            KeOps_Warning("There were warnings or errors compiling formula :", newline=True)
-            print(out.stderr.decode("utf-8"))
+            if os.name == 'nt':
+                KeOps_Warning("There were warnings or errors compiling formula :", newline=True)
+                print(out.stderr.decode("gbk"))
+            else:
+                KeOps_Warning("There were warnings or errors compiling formula :", newline=True)
+                print(out.stderr.decode("utf-8"))
     elif python_version >= (3, 5):
         import subprocess
 
@@ -52,7 +55,7 @@ def KeOps_OS_Run(command):
         os.system(command)
 
 
-def find_library_abspath(lib):
+def find_library_abspath_linux(lib):
     """
     wrapper around ctypes find_library that returns the full path
     of the library.
@@ -88,3 +91,33 @@ def find_library_abspath(lib):
     abspath = cast(lmptr, POINTER(LINKMAP)).contents.l_name
 
     return abspath.decode("utf-8")
+
+def find_library_abspath_windows(lib):
+    """
+    wrapper around ctypes find_library that returns the full path
+    of the library.
+    Warning : it also opens the shared library !
+    Adapted from
+    https://stackoverflow.com/questions/11007896/how-can-i-search-and-get-the-directory-of-a-dll-file-in-python
+    """
+    import ctypes
+    from ctypes.wintypes import HANDLE, LPWSTR, DWORD
+
+    GetModuleFileName = ctypes.windll.kernel32.GetModuleFileNameW
+    GetModuleFileName.argtypes = HANDLE, LPWSTR, DWORD
+    GetModuleFileName.restype = DWORD
+
+    MAX_PATH = 260
+    dll = ctypes.CDLL(lib) or ctypes.WINDLL(lib)
+    buf = ctypes.create_unicode_buffer(MAX_PATH)
+    GetModuleFileName(dll._handle, buf, MAX_PATH)
+    abspath = buf.value
+
+    return abspath
+
+def find_library_abspath(lib):
+    import os
+    if os.name == 'nt':
+        return find_library_abspath_windows(lib)
+    else:
+        return find_library_abspath_linux(lib)

--- a/keopscore/setup.py
+++ b/keopscore/setup.py
@@ -11,6 +11,10 @@ here = path.abspath(path.dirname(__file__))
 with open(os.path.join(here, "keopscore", "keops_version"), encoding="utf-8") as v:
     current_version = v.read().rstrip()
 
+if current_version.startswith('../'):
+    with open(os.path.join(here, "keopscore", current_version), encoding="utf-8") as v:
+        current_version = v.read().rstrip()
+
 # Get the long description from the README file
 with open(path.join(here, "keopscore", "readme.md"), encoding="utf-8") as f:
     long_description = f.read()

--- a/pykeops/pykeops/__init__.py
+++ b/pykeops/pykeops/__init__.py
@@ -30,6 +30,11 @@ with open(
 ) as v:
     __version__ = v.read().rstrip()
 
+here = os.path.abspath(os.path.dirname(__file__))
+if __version__.startswith('../'):
+    with open(os.path.join(here, __version__), encoding="utf-8") as v:
+        __version__ = v.read().rstrip()
+        
 ###########################################################
 # Utils
 

--- a/pykeops/pykeops/common/keops_io/CMakeLists.txt
+++ b/pykeops/pykeops/common/keops_io/CMakeLists.txt
@@ -1,0 +1,71 @@
+# example
+# cmake -G "Visual Studio 16 2019" -A x64 ../ -Dpybind11_DIR=C:\ProgramData\Anaconda3\envs\pt1.11_cu11.3\ lib\site-packages\pybind11\share\cmake\pybind11
+
+cmake_minimum_required(VERSION 3.12.0)
+
+set(CMAKE_BUILD_TYPE "Release")
+set(CMAKE_CXX_FLAGS_DEBUG "-g")
+set(CUDA_NVCC_FLAGS "--expt-relaxed-constexpr")
+
+# add_compile_definitions(IGL_STATIC_LIBRARY)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+project(PYKEOPS_NVRTC)
+
+#################### macro ####################
+add_definitions(-DARCHTAG=\"sm\")
+add_definitions(-DnvrtcGetTARGET=nvrtcGetCUBIN)
+add_definitions(-DnvrtcGetTARGETSize=nvrtcGetCUBINSize)
+
+#################### dependency ####################
+# cuda
+find_package(CUDA REQUIRED)
+set(CUDA_ARCH_BIN "86" CACHE STRING "Specify 'real' GPU arch to build binaries for, BIN(PTX) format is supported. Example: 1.3 2.1(1.3) or 13 21(13)")
+set(CUDA_ARCH_PTX "86" CACHE STRING "Specify 'virtual' PTX arch to build PTX intermediate code for. Example: 1.0 1.2 or 10 12")
+set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -ccbin g++ -O3) # -std=c++11  -Xptxas -g -allow-expensive-optimizations=true
+
+include_directories(${CUDA_INCLUDE_DIRS})
+message("CUDA_CUDART_LIBRARY = ${CUDA_CUDART_LIBRARY}")
+message("CUDA_LIBRARIES = ${CUDA_LIBRARIES}")
+message("CUDA_TOOLKIT_ROOT_DIR = ${CUDA_TOOLKIT_ROOT_DIR}")
+message("set nvrtc path = ${CUDA_TOOLKIT_ROOT_DIR}/lib/x64")
+link_directories(${CUDA_TOOLKIT_ROOT_DIR}/lib/x64)
+
+# pybind11
+find_package(pybind11 REQUIRED)
+include_directories(${pybind11_INCLUDE_DIRS})
+message("pybind11_INCLUDE_DIRS = ${pybind11_INCLUDE_DIRS}")
+message("PYTHON_LIBRARY = ${PYTHON_LIBRARY}")
+
+#################### src ####################
+# include
+include_directories(
+    "${CMAKE_CURRENT_SOURCE_DIR}/"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../keopscore/keopscore/"
+)
+
+file(GLOB SOURCES
+    "${CMAKE_CURRENT_SOURCE_DIR}/pykeops_nvrtc.cpp"
+)
+
+#################### compile ####################
+
+############################################################
+# target library
+add_library(pykeops_nvrtc SHARED ${SOURCES})
+target_link_libraries(pykeops_nvrtc
+    ${CUDA_CUDART_LIBRARY}
+    ${CUDA_LIBRARIES}
+    nvrtc
+    cuda
+    ${PYTHON_LIBRARY}
+)
+
+# change .dll to .pyd
+SET_TARGET_PROPERTIES( pykeops_nvrtc
+   PROPERTIES
+   SUFFIX ".pyd"
+)
+

--- a/pykeops/pykeops/common/keops_io/compile-win64.bat
+++ b/pykeops/pykeops/common/keops_io/compile-win64.bat
@@ -1,0 +1,48 @@
+@echo off
+set PWD=%~dp0
+set BUILD_DIR=%PWD%build
+echo %BUILD_DIR%
+
+if (%1) NEQ () (
+  set VCVARS64=%1
+)
+if (%2) NEQ () (
+  set PYBIND11_DIR=%2
+)
+
+if ((%VCVARS64%) == ()) (
+  echo "VCVARS64 not set, please add environ variable to vcvars64.bat"
+  set VCVARS64="C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+)
+if ((%VCVARS64%) == ("")) (
+  echo "VCVARS64 not set, please add environ variable to vcvars64.bat"
+  set VCVARS64="C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+)
+
+REM python -m pybind11 --cmakedir
+REM C:\ProgramData\Anaconda3\envs\pt1.11_cu11.3\lib\site-packages\pybind11\share\cmake\pybind11
+if (%PYBIND11_DIR%)==() (
+  set PYBIND11_DIR="C:\ProgramData\Anaconda3\envs\pt1.11_cu11.3\lib\site-packages\pybind11\share\cmake\pybind11"
+)
+if (%PYBIND11_DIR%)==("") (
+  set PYBIND11_DIR="C:\ProgramData\Anaconda3\envs\pt1.11_cu11.3\lib\site-packages\pybind11\share\cmake\pybind11"
+)
+
+echo --------------------------------------------------
+echo User defined path:
+echo VCVARS64 = %VCVARS64%
+echo PYBIND11_DIR = %PYBIND11_DIR%
+echo --------------------------------------------------
+
+REM enable vs
+call %VCVARS64%
+
+REM cmake
+cd /D %BUILD_DIR%
+
+cmake ../ -G Ninja -Dpybind11_DIR=%PYBIND11_DIR%
+
+REM build
+ninja -v
+
+REM pause

--- a/pykeops/pykeops/common/keops_io/pykeops_nvrtc.cpp
+++ b/pykeops/pykeops/common/keops_io/pykeops_nvrtc.cpp
@@ -22,7 +22,7 @@ public:
                    py::tuple py_dimsx, py::tuple py_dimsy, py::tuple py_dimsp,
                    py::tuple py_ranges,
                    py::tuple py_shapeout,
-                   long out_void,
+                   py::tuple out_void,
                    py::tuple py_arg,
                    py::tuple py_argshape
     ) {
@@ -64,7 +64,7 @@ public:
         // Cast the ranges arrays
         std::vector< int * > ranges_v(py_ranges.size());
         for (int i = 0; i < py_ranges.size(); i++)
-            ranges_v[i] = (int *) py::cast< long >(py_ranges[i]);
+            ranges_v[i] = (int *) py::cast< int64_t >(py_ranges[i]);
         int **ranges = (int **) ranges_v.data();
 
         // for (auto i: ranges_v)
@@ -79,12 +79,12 @@ public:
         for (auto i = 0; i < py_shapeout.size(); i++)
             shapeout_v[i] = py::cast< int >(py_shapeout[i]);
 
-        TYPE *out = (TYPE *) out_void;
+        TYPE *out = (TYPE *)py::cast< int64_t >(out_void[0]);
         // std::cout << "out_ptr : " << (long) out << std::endl;
 
         std::vector < TYPE * > arg_v(py_arg.size());
         for (int i = 0; i < py_arg.size(); i++)
-            arg_v[i] = (TYPE *) py::cast< long >(py_arg[i]);
+            arg_v[i] = (TYPE *) py::cast< int64_t >(py_arg[i]);
         TYPE **arg = (TYPE **) arg_v.data();
 
         std::vector <std::vector< int >> argshape_v(py_argshape.size());

--- a/pykeops/pykeops/common/utils.py
+++ b/pykeops/pykeops/common/utils.py
@@ -1,4 +1,4 @@
-import fcntl
+# import fcntl
 import functools
 import importlib.util
 import os

--- a/pykeops/pykeops/config.py
+++ b/pykeops/pykeops/config.py
@@ -12,14 +12,16 @@ torch_found = importlib.util.find_spec("torch") is not None
 from keopscore.config.config import use_cuda as gpu_available
 from keopscore.config.config import get_build_folder
 
+def pykeops_nvrtc_dir(type="src"):
+    return join(dirname(realpath(__file__)), "common", "keops_io") \
+        if type == "src" \
+        else get_build_folder()
 
 def pykeops_nvrtc_name(type="src"):
     basename = "pykeops_nvrtc"
     extension = ".cpp" if type == "src" else sysconfig.get_config_var("EXT_SUFFIX")
     return join(
-        join(dirname(realpath(__file__)), "common", "keops_io")
-        if type == "src"
-        else get_build_folder(),
+        pykeops_nvrtc_dir(type),
         basename + extension,
     )
 

--- a/pykeops/setup.py
+++ b/pykeops/setup.py
@@ -12,6 +12,10 @@ here = path.abspath(path.dirname(__file__))
 with open(os.path.join(here, "pykeops", "keops_version"), encoding="utf-8") as v:
     current_version = v.read().rstrip()
 
+if current_version.startswith('../'):
+    with open(os.path.join(here, "pykeops", current_version), encoding="utf-8") as v:
+        current_version = v.read().rstrip()
+
 # Get the long description from the README file
 with open(path.join(here, "pykeops", "readme.md"), encoding="utf-8") as f:
     long_description = f.read()

--- a/test/test_keopscore.py
+++ b/test/test_keopscore.py
@@ -1,0 +1,18 @@
+# python -m pybind11 --cmakedir
+# C:\ProgramData\Anaconda3\envs\pt1.11_cu11.3\lib\site-packages\pybind11\share\cmake\pybind11
+# python -m pybind11 --includes
+# -IC:\ProgramData\Anaconda3\envs\pt1.11_cu11.3\Include -IC:\ProgramData\Anaconda3\envs\pt1.11_cu11.3\lib\site-packages\pybind11\include
+
+from keopscore.config.config import get_compiler_library
+print('libcuda =', get_compiler_library('libcuda'))
+print('libnvrtc =', get_compiler_library('libnvrtc'))
+print('libcudart =', get_compiler_library('libcudart'))
+
+import keopscore
+import pykeops
+
+
+pykeops.test_numpy_bindings()
+pykeops.test_torch_bindings()
+
+pass


### PR DESCRIPTION
The original code manually call **gcc** to compile the code *JIT*. I've changed the compiling tool to cmake+ninja on windows. All changes are wrapped with `os.name == 'nt'` to be compatible.

##### To use the code:
 1. set `VCVARS64` to the `vcvars64.bat` file of your Visual Studio. Must do, because there's no other way to find your VS. 
![image](https://user-images.githubusercontent.com/4156648/207046422-f71b75a6-9177-48b0-8d02-384e3a828f1a.png)
*Do not add `"` in the variable*

2. make sure `cmake` is available.
![image](https://user-images.githubusercontent.com/4156648/207046815-55ca68d1-b6d8-442e-a557-025b5ff0d3c7.png)


3. make sure `pytorch` is available.
![image](https://user-images.githubusercontent.com/4156648/207046897-31f1f4f2-16c7-44fc-a3a0-bf1ffd1b22e9.png)

4. clone the repo
```
git clone https://github.com/initialneil/keops.git
cd keops
```

5. install `keopscore` and `pykeops`. Must use `develop` mode.
```
cd keopscore
python setup.py develop
cd ..

cd pykeops
python setup.py develop
cd ..
```

6. goto `test` to check bindings
```
cd test
python test_keopscore.py
```
![image](https://user-images.githubusercontent.com/4156648/207049116-c7373d25-cc75-454c-a473-c7f349f872f7.png)
JIT files will be generated and copied to `C:\Users\Admin\.cache\keops2.1\build`

7. if you encounter `CUDA Error`, please delete all files in `C:\Users\Admin\.cache\keops2.1\build` and use *step 6* again to regenerate the JIT files. Do not run `pykeops.test_numpy_bindings()` in `keopscore` or `pykeops` folders.