### PR TITLE
Do not include exact ranges in cache argument, but only their presence

### DIFF
--- a/pykeops/pykeops/torch/generic/generic_red.py
+++ b/pykeops/pykeops/torch/generic/generic_red.py
@@ -50,7 +50,7 @@ class GenredAutograd(torch.autograd.Function):
         # number of batch dimensions
         # N.B. we assume here that there is at least a cat=0 or cat=1 variable in the formula...
         nbatchdims = max(len(arg.shape) for arg in args) - 2
-        use_ranges = nbatchdims > 0 or ranges
+        use_ranges = nbatchdims > 0 or ranges is not None
 
         device_args = args[0].device
         if tagCPUGPU == 1 & tagHostDevice == 1:


### PR DESCRIPTION
The previous version passed the whole ranges version down to the cache implementation, which lead to the calculation of the str representation of the associated tensors, which is highly inefficient (i.a., it calls `tolist()`). Now, we only pass a boolean indicating whether we have ranges or not, which is already the default for the batch case.