### PR TITLE
Fix a memory leak when using range with no batch

### DIFF
--- a/keopscore/keopscore/binders/nvrtc/keops_nvrtc.cpp
+++ b/keopscore/keopscore/binders/nvrtc/keops_nvrtc.cpp
@@ -568,13 +568,13 @@ public :
             CUDA_SAFE_CALL(cuMemcpyDtoH(out, (CUdeviceptr) out_d, sizeof(TYPE) * sizeout));
         }
 
-         CUDA_SAFE_CALL(cuMemFree(p_data));
+        CUDA_SAFE_CALL(cuMemFree(p_data));
 
         if (RR.tagRanges == 1) {
             CUDA_SAFE_CALL(cuMemFree((CUdeviceptr) lookup_d));
+            CUDA_SAFE_CALL(cuMemFree((CUdeviceptr) slices_x_d));
+            CUDA_SAFE_CALL(cuMemFree((CUdeviceptr) ranges_y_d));
             if (SS.nbatchdims > 0) {
-                CUDA_SAFE_CALL(cuMemFree((CUdeviceptr) slices_x_d));
-                CUDA_SAFE_CALL(cuMemFree((CUdeviceptr) ranges_y_d));
                 CUDA_SAFE_CALL(cuMemFree((CUdeviceptr) offsets_d));
             }
         }


### PR DESCRIPTION
A fix for the memory leak I describe in [issue 284](https://github.com/getkeops/keops/issues/284#issuecomment-1594484422). Specifically, when using KeOps with ranges but no batch dimension, `slices_x_d` and `ranges_y_d` are not freed.