### PR TITLE
Update installation.rst -- troubleshoot missing cuda.h

### DIFF
--- a/doc/python/installation.rst
+++ b/doc/python/installation.rst
@@ -230,7 +230,7 @@ You can use the following test functions to compile and run simple KeOps formula
     import pykeops
     pykeops.test_numpy_bindings()    # perform the compilation
         
-  should return (see Troubleshooting 3 if if fails due to missing cuda.h file):
+  should return:
 
   .. code-block:: text
 
@@ -266,8 +266,8 @@ First of all, make sure that you are using a C++ compiler which is compatible wi
 
 2. Install a compiler **locally**: if you are using a conda environment, you can install a new instance of gcc and g++ by following the `documentation of conda <https://conda.io/docs/user-guide/tasks/build-packages/compiler-tools.html>`_.
 
-3. If you have a conda environment with CUDA toolkit and pykeops, the compiling test with pykeops.test_numpy_bindings()
-will fail unless you also have a system-wide CUDA toolkit installation, due to missing the cuda.h file. See https://conda-forge.org/docs/user/faq.html?highlight=cuda, question "How can I compile CUDA (host or device) codes in my environment?"
+3. If you have a conda environment with CUDA toolkit and pyKeOps, the compiling test with ``pykeops.test_numpy_bindings()``will fail unless you also have a system-wide CUDA toolkit installation, due to missing ``cuda.h`` file. See <https://conda-forge.org/docs/user/faq.html?highlight=cuda>`_, question "How can I compile CUDA (host or device) codes in my environment?"
+
 
 
 .. _`part.cache`:

--- a/doc/python/installation.rst
+++ b/doc/python/installation.rst
@@ -230,7 +230,7 @@ You can use the following test functions to compile and run simple KeOps formula
     import pykeops
     pykeops.test_numpy_bindings()    # perform the compilation
         
-  should return:
+  should return (see Troubleshooting 3 if if fails due to missing cuda.h file):
 
   .. code-block:: text
 
@@ -265,6 +265,9 @@ First of all, make sure that you are using a C++ compiler which is compatible wi
 1. Install a compiler **system-wide**: for instance, on Debian-based Linux distributions, you can install g++ with apt and then use `update-alternatives <https://askubuntu.com/questions/26498/choose-gcc-and-g-version>`_ to choose a suitable compiler as default. Don't forget to pick compatible versions for both **gcc** and **g++**.  
 
 2. Install a compiler **locally**: if you are using a conda environment, you can install a new instance of gcc and g++ by following the `documentation of conda <https://conda.io/docs/user-guide/tasks/build-packages/compiler-tools.html>`_.
+
+3. If you have a conda environment with CUDA toolkit and pykeops, the compiling test with pykeops.test_numpy_bindings()
+will fail unless you also have a system-wide CUDA toolkit installation, due to missing the cuda.h file. See https://conda-forge.org/docs/user/faq.html?highlight=cuda, question "How can I compile CUDA (host or device) codes in my environment?"
 
 
 .. _`part.cache`:


### PR DESCRIPTION
Added a note that when running pykeops from a conda enviroment, pykeops.test_torch_bindings() will fail due to cuda.h missing unless a system-wide installation of CUDA toolkit is available. I included the link to the NVIDIA FAQ that explains that the conda-forge install of CUDA toolkit does NOT contain the full toolchain with the compilers. https://conda-forge.org/docs/user/faq.html?highlight=cuda, question  "How can I compile CUDA (host or device) codes in my environment?"