### PR TITLE
Debug gpu_utils.py - unique temporary files for parallel execution

### DIFF
--- a/keopscore/keopscore/utils/gpu_utils.py
+++ b/keopscore/keopscore/utils/gpu_utils.py
@@ -1,5 +1,6 @@
 import ctypes
 from ctypes.util import find_library
+import tempfile
 
 import keopscore.config.config
 from keopscore.utils.misc_utils import (
@@ -87,7 +88,7 @@ def get_cuda_include_path():
 
 
 def get_include_file_abspath(filename):
-    tmp_file = join(get_build_folder(), "tmp.txt")
+    tmp_file = tempfile.NamedTemporaryFile(dir=get_build_folder()).name
     KeOps_OS_Run(
         f'echo "#include <{filename}>" | {cxx_compiler} -M -E -x c++ - | head -n 2 > {tmp_file}'
     )


### PR DESCRIPTION
When keops are used in parallel runs (e.g. when sweeping), the temporary file created in `gpu_utils.py` did have the same name leading to a race condition on the file system and `FileNotFoundError`s.
This PR fixes this by creating unique temporary files using the Python standard library.
Fixes #324 