### PR TITLE
redirect stdout upon import without gpu

### DIFF
--- a/keopscore/keopscore/config/config.py
+++ b/keopscore/keopscore/config/config.py
@@ -126,9 +126,11 @@ if use_OpenMP:
 
         res = subprocess.run(
             'echo "#include <omp.h>" | g++ -E - -o /dev/null',
-            stdout=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
             shell=True,
         )
+        
         if res.returncode != 0:
             KeOps_Warning("omp.h header is not in the path, disabling OpenMP.")
             use_OpenMP = False


### PR DESCRIPTION
I'm wondering if you wouldn't mind redirecting / stashing the stdout message when there is no GPU detected? I'm able to hide the other warnings when via `os.environ["KEOPS_VERBOSE"] = "0"`, though avoidance of the following error message is more difficult without force silencing (to my knowledge). From my perspective, it would be great to include this small edit,  if you feel it is acceptable. Thank you for your consideration.