### PR TITLE
Add missing folder in keopscore setup

### DIFF
--- a/keopscore/setup.py
+++ b/keopscore/setup.py
@@ -50,7 +50,7 @@ setup(
         "keopscore.formulas.autodiff",
         "keopscore.formulas.complex",
         "keopscore.formulas.LinearOperators",
-        # "keopscore.formulas.factorization",
+        "keopscore.formulas.factorization",
         "keopscore.formulas.maths",
         "keopscore.formulas.reductions",
         "keopscore.formulas.variables",

--- a/keopscore/setup.py
+++ b/keopscore/setup.py
@@ -50,6 +50,7 @@ setup(
         "keopscore.formulas.autodiff",
         "keopscore.formulas.complex",
         "keopscore.formulas.LinearOperators",
+        # "keopscore.formulas.factorization",
         "keopscore.formulas.maths",
         "keopscore.formulas.reductions",
         "keopscore.formulas.variables",


### PR DESCRIPTION
Same as PR #338  I don't know why I only got this error now. Another alternative is to use `setuptools.findpackage`.