### PR TITLE
Add build_folder to sys.path if needed before importing pykeops_nvrtc

### DIFF
--- a/pykeops/pykeops/common/keops_io/LoadKeOps_nvrtc.py
+++ b/pykeops/pykeops/common/keops_io/LoadKeOps_nvrtc.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import keopscore.config.config
 from keopscore.config.config import get_build_folder
@@ -16,6 +17,10 @@ class LoadKeOps_nvrtc_class(LoadKeOps):
 
     def init_phase2(self):
         import importlib
+        if pykeops.get_build_folder() not in sys.path:
+            # The build folder is supposed to be in the python path, if not,
+            # we add it
+            sys.path.append(pykeops.get_build_folder())
 
         pykeops_nvrtc = importlib.import_module("pykeops_nvrtc")
 


### PR DESCRIPTION
Resolves #352 

If the `build_folder` was removed from `sys.path` by the user or another program, it is added again just before importing `pykeops_nvrtc`.