### PR TITLE
fix: conda cuda detection

### DIFF
--- a/keopscore/keopscore/config/cuda.py
+++ b/keopscore/keopscore/config/cuda.py
@@ -300,12 +300,13 @@ class CUDAConfig:
         # Check if CUDA is installed via conda
         conda_prefix = os.getenv("CONDA_PREFIX")
         if conda_prefix:
-            include_path = Path(conda_prefix) / "include"
-            if (include_path / "cuda.h").is_file() and (
-                include_path / "nvrtc.h"
-            ).is_file():
-                self.cuda_include_path = str(include_path)
-                return self.cuda_include_path
+            for arch in ["", "targets/x86_64-linux", "targets/ppc64le-linux", "targets/sbsa-linux"]:
+                include_path = Path(conda_prefix) /  arch / "include"
+                if (include_path / "cuda.h").is_file() and (
+                    include_path / "nvrtc.h"
+                ).is_file():
+                    self.cuda_include_path = str(include_path)
+                    return self.cuda_include_path
 
         # Check standard locations
         cuda_version_str = self.get_cuda_version(out_type="string")

--- a/keopscore/keopscore/config/cuda.py
+++ b/keopscore/keopscore/config/cuda.py
@@ -1,28 +1,32 @@
-import os
 import ctypes
-from ctypes.util import find_library
-from ctypes import (
-    c_int,
-    c_void_p,
-    c_char_p,
-    CDLL,
-    byref,
-    cast,
-    POINTER,
-    Structure,
-    RTLD_GLOBAL,
-)
-from pathlib import Path
-import shutil
-from os.path import join
+import os
 import platform
-import tempfile
+import shutil
 import subprocess
 import sys
+import tempfile
+from ctypes import (
+    CDLL,
+    POINTER,
+    RTLD_GLOBAL,
+    Structure,
+    byref,
+    c_char_p,
+    c_int,
+    c_void_p,
+    cast,
+)
+from ctypes.util import find_library
+from os.path import join
+from pathlib import Path
+
 import keopscore
-from keopscore.utils.misc_utils import KeOps_Warning
-from keopscore.utils.misc_utils import KeOps_OS_Run
-from keopscore.utils.misc_utils import CHECK_MARK, CROSS_MARK
+from keopscore.utils.misc_utils import (
+    CHECK_MARK,
+    CROSS_MARK,
+    KeOps_OS_Run,
+    KeOps_Warning,
+)
 
 
 class CUDAConfig:
@@ -300,8 +304,13 @@ class CUDAConfig:
         # Check if CUDA is installed via conda
         conda_prefix = os.getenv("CONDA_PREFIX")
         if conda_prefix:
-            for arch in ["", "targets/x86_64-linux", "targets/ppc64le-linux", "targets/sbsa-linux"]:
-                include_path = Path(conda_prefix) /  arch / "include"
+            for arch in [
+                "",
+                "targets/x86_64-linux",
+                "targets/ppc64le-linux",
+                "targets/sbsa-linux",
+            ]:
+                include_path = Path(conda_prefix) / arch / "include"
                 if (include_path / "cuda.h").is_file() and (
                     include_path / "nvrtc.h"
                 ).is_file():


### PR DESCRIPTION
Fixes cuda file detection for linux cuda users.
Without this patch, pykeops fails to find `cuda.h` and switches back to cpu only mode.

From `conda-nvcc`'s `activate.sh` file, the relevent variables are the following:
```sh
#...

[[ "@cross_target_platform@" == "linux-64" ]] && targetsDir="targets/x86_64-linux"
[[ "@cross_target_platform@" == "linux-ppc64le" ]] && targetsDir="targets/ppc64le-linux"
[[ "@cross_target_platform@" == "linux-aarch64" ]] && targetsDir="targets/sbsa-linux"


CUDA_CFLAGS=""
CUDA_LDFLAGS=""
if [ "${CONDA_BUILD:-0}" = "1" ]; then
    CUDA_CFLAGS="${CUDA_CFLAGS} -I${PREFIX}/${targetsDir}/include"
    CUDA_CFLAGS="${CUDA_CFLAGS} -I${BUILD_PREFIX}/${targetsDir}/include"
    CUDA_LDFLAGS="${CUDA_LDFLAGS} -L${PREFIX}/${targetsDir}/lib"
    CUDA_LDFLAGS="${CUDA_LDFLAGS} -L${PREFIX}/${targetsDir}/lib/stubs"
    CUDA_LDFLAGS="${CUDA_LDFLAGS} -L${BUILD_PREFIX}/${targetsDir}/lib"
    CUDA_LDFLAGS="${CUDA_LDFLAGS} -L${BUILD_PREFIX}/${targetsDir}/lib/stubs"
    # Needed to fix cross compilation.
    # $PREFIX and $PREFIX/${targetsDir} are needed to properly find all host components
    # $BUILD_PREFIX/$HOST/sysroot is needed to find compiler bits and is placed before any `targetsDir` for priority.
    # $BUILD_PREFIX/${targetsDir} is needed for projects that don't enable the CUDA language but use FindCUDAToolkit
    export CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_FIND_ROOT_PATH=$PREFIX;$BUILD_PREFIX/$HOST/sysroot;$PREFIX/${targetsDir};$BUILD_PREFIX/${targetsDir}"
else
    CUDA_CFLAGS="${CUDA_CFLAGS} -I${CONDA_PREFIX}/${targetsDir}/include"
    CUDA_LDFLAGS="${CUDA_LDFLAGS} -L${CONDA_PREFIX}/${targetsDir}/lib"
    CUDA_LDFLAGS="${CUDA_LDFLAGS} -L${CONDA_PREFIX}/${targetsDir}/lib/stubs"
fi
export CFLAGS="${CFLAGS} ${CUDA_CFLAGS}"
export CPPFLAGS="${CPPFLAGS} ${CUDA_CFLAGS}"
export CXXFLAGS="${CXXFLAGS} ${CUDA_CFLAGS}"
export LDFLAGS="${LDFLAGS} ${CUDA_LDFLAGS}"

# ...
```
https://github.com/conda-forge/cuda-nvcc-feedstock/blob/e4330bbc991b31e6f3e775524667b806f5495dcf/recipe/activate.sh#L5-L31

So I just added the different possible `targetDirs` to the `keopscore` file detection pipeline, and it worked on my laptop.
