### PR TITLE
Mac os config

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,7 +17,7 @@ task:
   script:
     - brew install libomp
     - brew install python@3.11
-    - $(brew --prefix python@3.12)/bin/python3.12 -m venv .test_venv
+    - $(brew --prefix python@3.11)/bin/python3.11 -m venv .test_venv
     - source .test_venv/bin/activate
     - pip install --upgrade pip
     - sh ./pytest.sh

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,7 +16,7 @@ task:
 
   script:
     - brew install libomp
-    - brew install python@3.12
+    - brew install python@3.11
     - $(brew --prefix python@3.12)/bin/python3.12 -m venv .test_venv
     - source .test_venv/bin/activate
     - pip install --upgrade pip

--- a/keopscore/keopscore/config/cuda.py
+++ b/keopscore/keopscore/config/cuda.py
@@ -16,13 +16,12 @@ from pathlib import Path
 import shutil
 from os.path import join
 import platform
-import tempfile
 import subprocess
 import sys
 import keopscore
 from keopscore.utils.misc_utils import KeOps_Warning
 from keopscore.utils.misc_utils import KeOps_OS_Run
-from keopscore.utils.misc_utils import CHECK_MARK, CROSS_MARK
+from keopscore.utils.misc_utils import CHECK_MARK, CROSS_MARK, get_include_file_abspath
 
 
 class CUDAConfig:
@@ -341,17 +340,7 @@ class CUDAConfig:
         return self.cuda_include_path
 
     def get_include_file_abspath(self, filename):
-        tmp_file = tempfile.NamedTemporaryFile(dir=self.get_build_folder()).name
-        KeOps_OS_Run(
-            f'echo "#include <{filename}>" | {self.cxx_compiler} -M -E -x c++ - | head -n 2 > {tmp_file}'
-        )
-        strings = open(tmp_file).read().split()
-        abspath = None
-        for s in strings:
-            if filename in s:
-                abspath = s
-        os.remove(tmp_file)
-        return abspath
+        return get_include_file_abspath(filename, self.cxx_compiler)
 
     def set_nvrtc_flags(self):
         """Set the NVRTC flags for CUDA compilation."""

--- a/keopscore/keopscore/utils/gpu_utils.py
+++ b/keopscore/keopscore/utils/gpu_utils.py
@@ -1,6 +1,5 @@
 import ctypes
 from ctypes.util import find_library
-import tempfile
 
 
 from keopscore.utils.misc_utils import (
@@ -8,6 +7,7 @@ from keopscore.utils.misc_utils import (
     KeOps_Warning,
     find_library_abspath,
     KeOps_OS_Run,
+    get_include_file_abspath,
 )
 
 import keopscore
@@ -81,7 +81,7 @@ def get_cuda_include_path():
 
     # last try, testing if by any chance the header is already in the default
     # include path of gcc
-    path_cudah = get_include_file_abspath("cuda.h")
+    path_cudah = get_include_file_abspath("cuda.h", config.cxx_compiler())
     if path_cudah:
         path = os.path.dirname(path_cudah)
     if os.path.isfile(join(path, "nvrtc.h")):
@@ -98,20 +98,6 @@ def get_cuda_include_path():
       os.environ['CUDA_PATH'] = '/vol/cuda/10.2.89-cudnn7.6.4.38'
     """
     )
-
-
-def get_include_file_abspath(filename):
-    tmp_file = tempfile.NamedTemporaryFile(dir=config.get_build_folder()).name
-    KeOps_OS_Run(
-        f'echo "#include <{filename}>" | {config.cxx_compiler()} -M -E -x c++ - | head -n 2 > {tmp_file}'
-    )
-    strings = open(tmp_file).read().split()
-    abspath = None
-    for s in strings:
-        if filename in s:
-            abspath = s
-    os.remove(tmp_file)
-    return abspath
 
 
 def orig_cuda_include_fp16_path():

--- a/pytest.sh
+++ b/pytest.sh
@@ -64,7 +64,7 @@ PROJDIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 PYTHON="python3"
 
 # python environment for test
-TEST_VENV=${PROJDIR}/.test_venv
+TEST_VENV=${PROJDIR}/.test_venv_pytest
 
 # python test requirements (names of packages to be installed with pip)
 TEST_REQ="pip"


### PR DESCRIPTION
Switching to Python 3.11 in CI config for Mac OS, as Python >= 3.12 doesn't completely work due to some bug with pybind11. We will need to fix this later.