### PR TITLE
fix view typo (for numpy2)

### DIFF
--- a/pykeops/pykeops/common/lazy_tensor.py
+++ b/pykeops/pykeops/common/lazy_tensor.py
@@ -179,9 +179,9 @@ class GenericLazyTensor:
             )
 
         if typex == self.tools.arraytype and len(x.shape) == 0:
-            x = x.view(1)
+            x = x.reshape(1)
         elif typex in self.tools.float_types:
-            x = self.tools.arraytype([x]).view(1)
+            x = self.tools.arraytype([x]).reshape(1)
 
         if typex == self.tools.arraytype:
             if len(x.shape) >= 3:  # Infer axis from the input shape


### PR DESCRIPTION
Numpy array can be of dimension 0, which can be problematic with `view(1)` with Numpy2.

This fails for instance
```python
from pykeops.numpy import LazyTensor
import numpy as np
z = LazyTensor(np.random.rand(10, 1, 3).astype(np.float32))
s = np.array(0.1, dtype=np.float32)
#  pykeops/common/lazy_tensor.py:182
res = z / s 
```
while
```python
from pykeops.numpy import LazyTensor
import numpy as np
z = LazyTensor(np.random.rand(10, 1, 3).astype(np.float32))
s = np.array(0.1, dtype=np.float32).reshape(1)
#  pykeops/common/lazy_tensor.py:182
res = z / s 
```
doesn't.